### PR TITLE
Switch cropperWindowBuffer to const

### DIFF
--- a/app/src/main/main.js
+++ b/app/src/main/main.js
@@ -26,6 +26,7 @@ require('./reporter');
 
 let appState = 'initial';
 let cropperWindow;
+const cropperWindowBuffer = 4;
 let mainWindowIsDetached = false;
 let mainWindow;
 let mainWindowIsNew = true;
@@ -51,7 +52,7 @@ ipcMain.on('set-main-window-size', (event, args) => {
 ipcMain.on('set-cropper-window-size', (event, args) => {
   if (args.width && args.height && cropperWindow) {
     [args.width, args.height] = [parseInt(args.width, 10), parseInt(args.height, 10)];
-    cropperWindow.setSize(args.width, args.height, true); // true == animate
+    cropperWindow.setSize(args.width + cropperWindowBuffer, args.height + cropperWindowBuffer, true); // true == animate
   }
 });
 
@@ -82,8 +83,8 @@ ipcMain.on('open-cropper-window', (event, size) => {
     cropperWindow.focus();
   } else {
     cropperWindow = new BrowserWindow({
-      width: size.width,
-      height: size.height,
+      width: size.width + cropperWindowBuffer,
+      height: size.height + cropperWindowBuffer,
       frame: false,
       transparent: true,
       resizable: true,


### PR DESCRIPTION
Taking a stab at https://github.com/wulkano/kap/issues/25. I noticed in the renderer `index.js` the cropperBounds width and height are being subtracted by 4px. Seen [here]:(https://github.com/wulkano/kap/blob/master/app/src/renderer/js/index.js#L100-L101)

```javascript
cropperBounds.width -= 4;
cropperBounds.height -= 4;
```

So I added a `cropperWindowBuffer` which sets the cropperWindow preview 4px wider and taller, but correctly exports the same dimensions now.

![kap-dimensions-fix](https://cloud.githubusercontent.com/assets/527849/19204241/459019f0-8ca1-11e6-8211-9136ef4afa49.gif)
