### PR TITLE
README: brew cask update to brew update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download the latest release [here](https://getkap.co/download). (macOS/OS X only
 
 Kap is also available with Homebrew Cask. Download using the following commands:
 ```
-$ brew cask update
+$ brew update
 $ brew cask install kap
 ```
 


### PR DESCRIPTION
`brew cask update` is simply a convenience alias to `brew update`. We don’t really promote `brew cask update` as that leads users to erroneously `brew update && brew cask update`, basically running the same command twice.