### PR TITLE
Fix window without eightpoint

### DIFF
--- a/app/src/renderer/css/cropper.css
+++ b/app/src/renderer/css/cropper.css
@@ -3,6 +3,7 @@
 html, body {
   width: 100%;
   height: 100%;
+  margin: 0px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Currently eighpoint helps the window to remove the default margin.

But, for other interests looking into this project, makes hard to find out why the window looks wired without eightpoint.
So I've added the zero margin to the cropper css.

Further reading: https://github.com/wulkano/kap/issues/81 