### PR TITLE
Add extra default aspect ratios

### DIFF
--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -59,7 +59,9 @@ html(lang='en')
                 select.aspect-ratio-selector
                   option(value='1600x900') 16:9 (1600x900)
                   option(value='1280x1024') 5:4 (1280x1024)
+                  option(value='1280x768') 5:3 (1280x768)
                   option(value='1024x768') 4:3 (1024x768)
+                  option(value='480x320') 3:2 (480x320)
                   option(value='512x512', selected='selected') 1:1 (512x512)
                   option(data-aspect-ratio='custom') Custom
             .controls-section__row.aspect-ratio


### PR DESCRIPTION
Added the following default aspect ratios (per @skllcrn's recommendation)
- 5:3 (1280×768)
- 3:2 (480×320)
