### PR TITLE
Ignore file drops in Kap

### DIFF
--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -201,3 +201,6 @@ document.addEventListener('DOMContentLoaded', () => {
     windowHeader.classList.toggle('is-hidden');
   };
 });
+
+document.addEventListener('dragover', e => e.preventDefault());
+document.addEventListener('drop', e => e.preventDefault());

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -442,4 +442,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initErrorReporter();
 });
 
+document.addEventListener('dragover', e => e.preventDefault());
+document.addEventListener('drop', e => e.preventDefault());
+
 window.addEventListener('load', setMainWindowSize);

--- a/app/src/renderer/js/preferences.js
+++ b/app/src/renderer/js/preferences.js
@@ -95,3 +95,6 @@ document.addEventListener('DOMContentLoaded', () => {
     app.kap.settings.set('sound', this.checked);
   };
 });
+
+document.addEventListener('dragover', e => e.preventDefault());
+document.addEventListener('drop', e => e.preventDefault());


### PR DESCRIPTION
This fixes https://github.com/wulkano/kap/issues/97. It prevents dropping files in the *Main*, *Editor*, and *Preferences* windows. The Cropper window did not respond to file drops, so I let that alone.

![kapture 2016-12-09 at 16 05 54](https://cloud.githubusercontent.com/assets/527849/21066115/71163ca8-be29-11e6-9022-40a3f90813d3.gif)
