### PR TITLE
Ensure the `Control` toggle gets a hand cursor

### DIFF
--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -108,7 +108,7 @@
 
     /* Text inside the toggle */
     &__title {
-      cursor: pointer;
+      cursor: pointer !important;
       margin-left: 1rem;
     }
 


### PR DESCRIPTION
It didn't work previously as something else was overriding its style.