### PR TITLE
Updating ffmpeg download URL.

### DIFF
--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 let spinner = ora({text: 'Installing 7zip', stream: process.stdout}).start();
 
-const FFMPEG_URL = 'http://evermeet.cx/ffmpeg/ffmpeg-82622-g42ae9c6.7z';
+const FFMPEG_URL = 'http://evermeet.cx/ffmpeg/ffmpeg-83544-g965f35b.7z';
 const VENDOR_PATH = ['..', 'app', 'vendor'];
 
 const joinPath = (...str) => path.join(__dirname, ...str);


### PR DESCRIPTION
_npm install_ was failing when attempting to download ffmpeg at an erroring URL.

This updates the URL to its valid equivalent.