### PR TITLE
Upgrade Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cssnano": "3.7.7",
     "del": "2.2.2",
     "eightpoint": "0.0.1",
-    "electron": "1.5.1",
+    "electron": "1.6.9",
     "electron-builder": "17.5.0",
     "execa": "0.5.0",
     "got": "6.5.0",


### PR DESCRIPTION
We should not get too far behind as we’ll need some fixes from the latest Electron version in the future. I’m intentionally not upgrading to 1.7.0 yet as it’s still unstable.

I tested it thoroughly and couldn't find any regressions, but help test: https://kap-artifacts.now.sh/bump-electron
