### PR TITLE
Catch unhandled errors and promise rejections

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "eightpoint": "0.0.1",
     "electron-is-dev": "^0.1.2",
     "electron-settings": "^2.2.1",
+    "electron-unhandled": "^0.1.1",
     "execa": "^0.5.0",
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",

--- a/app/src/common/reporter.js
+++ b/app/src/common/reporter.js
@@ -1,4 +1,5 @@
 import isDev from 'electron-is-dev';
+import unhandled from 'electron-unhandled';
 
 let ravenClient;
 
@@ -12,10 +13,16 @@ function init() {
 }
 
 function report(err) {
-  if (!isDev && err) {
+  console.error(err);
+
+  if (!isDev && ravenClient && err) {
     ravenClient.captureException(err);
   }
 }
+
+unhandled({
+  logger: report
+});
 
 exports.init = init;
 exports.report = report;

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -214,7 +214,6 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(err => {
         ipcRenderer.send('will-stop-recording');
-        log(err);
         reportError(err);
         remote.dialog.showErrorBox('Recording error', err.message);
       });

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -94,6 +94,10 @@ chalk@^1.0.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+clean-stack@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.2.0.tgz#a465128d62c31fb1a3606d00abfe59dcf652f568"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -239,6 +243,12 @@ electron-settings@^2.2.1:
     file-exists "^2.0.0"
     fs-extra "^0.30.0"
     key-path-helpers "^0.4.0"
+
+electron-unhandled@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/electron-unhandled/-/electron-unhandled-0.1.1.tgz#ff26ec781cccb130b295d43bf406c1ebc05fe1d5"
+  dependencies:
+    clean-stack "^1.2.0"
 
 error-ex@^1.2.0:
   version "1.3.0"


### PR DESCRIPTION
No more silent failures!

Previously, if we had for example the following without a catch handler, it would just fail silently:

```js
Promise.reject(new Error('Could not find 🦄'));
```

Now it will both report it to Sentry and inform the user:

<img width="532" alt="screen shot 2017-05-15 at 14 24 11" src="https://cloud.githubusercontent.com/assets/170270/26046983/90dc2a16-397b-11e7-8bc5-22f8ddf8c2a5.png">

It handles unhandled errors/rejections in both the main and renderer process.