### PR TITLE
Add APNG support

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -443,6 +443,8 @@ ipcMain.on('open-editor-window', (event, opts) => {
     frame: false
   });
 
+  app.kap.editorWindow = editorWindow;
+
   editorWindow.loadURL(`file://${__dirname}/../renderer/views/editor.html`);
 
   editorWindow.webContents.on('did-finish-load', () => editorWindow.webContents.send('video-src', opts.filePath));
@@ -467,7 +469,6 @@ ipcMain.on('open-editor-window', (event, opts) => {
     }
   });
 
-  app.kap.editorWindow = editorWindow;
   menubar.setOption('hidden', true);
   mainWindow.hide();
   tray.setHighlightMode('never');

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -436,10 +436,10 @@ ipcMain.on('open-editor-window', (event, opts) => {
   }
 
   editorWindow = new BrowserWindow({
-    width: 768,
-    minWidth: 768,
-    height: 428,
-    minHeight: 428,
+    width: 800,
+    minWidth: 800,
+    height: 430,
+    minHeight: 430,
     frame: false
   });
 

--- a/app/src/main/save-file.js
+++ b/app/src/main/save-file.js
@@ -9,8 +9,10 @@ module.exports = (type, defaultFileName) => {
     filters = [{name: 'Movies', extensions: ['mp4']}];
   } else if (type === 'webm') {
     filters = [{name: 'Movies', extensions: ['webm']}];
-  } else {
+  } else if (type === 'gif') {
     filters = [{name: 'Images', extensions: ['gif']}];
+  } else {
+    filters = [{name: 'Images', extensions: ['apng']}];
   }
 
   return makeDir(kapturesDir).then(() => {

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -512,8 +512,9 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!outputPath) {
         return;
       }
-
-      app.kap.editorWindow.send('toggle-format-buttons', {enabled: false});
+      // Initially an exception is triggered that editorWindow is undefined
+      // Using getter here should make it 'safer'
+      app.kap.getEditorWindow().send('toggle-format-buttons', {enabled: false});
       app.kap.mainWindow.show();
 
       const input = Object.assign({}, data, {outputPath});

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -512,9 +512,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!outputPath) {
         return;
       }
-      // Initially an exception is triggered that editorWindow is undefined
-      // Using getter here should make it 'safer'
-      app.kap.getEditorWindow().send('toggle-format-buttons', {enabled: false});
+
+      app.kap.editorWindow.send('toggle-format-buttons', {enabled: false});
       app.kap.mainWindow.show();
 
       const input = Object.assign({}, data, {outputPath});

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -503,7 +503,6 @@ document.addEventListener('DOMContentLoaded', () => {
       convert = convertToApng;
     }
 
-
     const now = moment();
     const defaultFileName = `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.${type}`;
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -6,7 +6,7 @@ import aspectRatio from 'aspectratio';
 import fileSize from 'file-size';
 import moment from 'moment';
 
-import {convertToGif, convertToMp4, convertToWebm} from '../../scripts/convert';
+import {convertToGif, convertToMp4, convertToWebm, convertToApng} from '../../scripts/convert';
 import {init as initErrorReporter, report as reportError} from '../../common/reporter';
 import {log} from '../../common/logger';
 
@@ -499,7 +499,10 @@ document.addEventListener('DOMContentLoaded', () => {
       convert = convertToMp4;
     } else if (type === 'webm') {
       convert = convertToWebm;
+    } else if (type === 'apng') {
+      convert = convertToApng;
     }
+
 
     const now = moment();
     const defaultFileName = `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.${type}`;

--- a/app/src/renderer/views/editor.pug
+++ b/app/src/renderer/views/editor.pug
@@ -53,3 +53,5 @@ block body
         span MP4
       button.button--primary(data-export-type="webm")
         span WebM
+      button.button--primary(data-export-type="apng")
+        span APNG

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -82,20 +82,20 @@ function convertToWebm(opts) {
   });
 }
 
-// should be similiar to the Gif generation
+// Should be similiar to the Gif generation
 function convertToApng(opts) {
-    return Promise.resolve().then(() => {
+  return Promise.resolve().then(() => {
     const palettePath = tmp.tmpNameSync({postfix: '.png'});
 
     return execa(ffmpeg, [
       '-i', opts.filePath,
-      '-vf', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos,palettegen`,
+      '-vf', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos`,
       palettePath
     ])
       .then(() => convert(opts.outputPath, opts, [
         '-i', opts.filePath,
         '-i', palettePath,
-        '-filter_complex', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos[x]; [x][1:v]paletteuse`,
+        '-filter_complex', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos[x]; [x][1:v]`,
         `-loop`, opts.loop === true ? '0' : '-1', // 0 == forever; -1 == no loop
         opts.outputPath
       ]));

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -82,6 +82,27 @@ function convertToWebm(opts) {
   });
 }
 
+// should be similiar to the Gif generation
+function convertToApng(opts) {
+    return Promise.resolve().then(() => {
+    const palettePath = tmp.tmpNameSync({postfix: '.png'});
+
+    return execa(ffmpeg, [
+      '-i', opts.filePath,
+      '-vf', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos,palettegen`,
+      palettePath
+    ])
+      .then(() => convert(opts.outputPath, opts, [
+        '-i', opts.filePath,
+        '-i', palettePath,
+        '-filter_complex', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos[x]; [x][1:v]paletteuse`,
+        `-loop`, opts.loop === true ? '0' : '-1', // 0 == forever; -1 == no loop
+        opts.outputPath
+      ]));
+  });
+}
+
 exports.convertToGif = convertToGif;
 exports.convertToMp4 = convertToMp4;
 exports.convertToWebm = convertToWebm;
+exports.convertToApng = convertToApng;

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -85,20 +85,12 @@ function convertToWebm(opts) {
 // Should be similiar to the Gif generation
 function convertToApng(opts) {
   return Promise.resolve().then(() => {
-    const palettePath = tmp.tmpNameSync({postfix: '.png'});
-
-    return execa(ffmpeg, [
+    return convert(opts.outputPath, opts, [
       '-i', opts.filePath,
-      '-vf', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos`,
-      palettePath
-    ])
-      .then(() => convert(opts.outputPath, opts, [
-        '-i', opts.filePath,
-        '-i', palettePath,
-        '-filter_complex', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos[x]; [x][1:v]`,
-        `-loop`, opts.loop === true ? '0' : '-1', // 0 == forever; -1 == no loop
-        opts.outputPath
-      ]));
+      // Strange for apng instaed of -loop it uses -plays see: https://stackoverflow.com/questions/43795518/using-ffmpeg-to-create-looping-apng
+      `-plays`, opts.loop === true ? '0' : '-1', // 0 == forever; -1 == no loop
+      opts.outputPath
+    ]);
   });
 }
 

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -87,7 +87,8 @@ function convertToApng(opts) {
   return Promise.resolve().then(() => {
     return convert(opts.outputPath, opts, [
       '-i', opts.filePath,
-      // Strange for apng instaed of -loop it uses -plays see: https://stackoverflow.com/questions/43795518/using-ffmpeg-to-create-looping-apng
+      '-vf', `fps=${opts.fps},scale=${opts.width}:${opts.height}:flags=lanczos[x]`,
+      // Strange for APNG instead of -loop it uses -plays see: https://stackoverflow.com/questions/43795518/using-ffmpeg-to-create-looping-apng
       `-plays`, opts.loop === true ? '0' : '-1', // 0 == forever; -1 == no loop
       opts.outputPath
     ]);

--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 let spinner = ora({text: 'Installing 7zip', stream: process.stdout}).start();
 
-const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-85767-gdec2fa8.7z';
+const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-86241-gfb75ad7.7z';
 const VENDOR_PATH = ['..', 'app', 'vendor'];
 
 const joinPath = (...str) => path.join(__dirname, ...str);

--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 let spinner = ora({text: 'Installing 7zip', stream: process.stdout}).start();
 
-const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-86241-gfb75ad7.7z';
+const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-85767-gdec2fa8.7z';
 const VENDOR_PATH = ['..', 'app', 'vendor'];
 
 const joinPath = (...str) => path.join(__dirname, ...str);


### PR DESCRIPTION
I've added a first apng support as commented in #164 . 

I'm not experienced enough to be 100% sure if my converter function to apng is really the best one. Sadly the FFMpeg website has no clear information regarding APNG Muxer. According to https://github.com/FFmpeg/FFmpeg/blob/master/Changelog#L253 ffmpeg has basic APNG support since v2.7.

- I added a convertToApng function
- tested in on dev mode + on the dist dmg file after running `npm run pack` and it is working
- Tested .apng functionality on FF v53 and Chrome Canary v60.X
-  it is working 🎉 .

The only "concern" is that .apng's with the current convert function tend to be quite 'fat', e.g. the .gif below is X mb whereas the same .apng is 21,4 MB 😨

![dogfood_convertapng](https://cloud.githubusercontent.com/assets/1215719/26399853/d0ee72ee-407e-11e7-88a7-f72605031491.gif)

Maybe someone here has more experience and can help me out with better flags / filters.




