### PR TITLE
Remove shadow from the cropper window

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -95,7 +95,7 @@ ipcMain.on('open-cropper-window', (event, size) => {
       frame: false,
       transparent: true,
       resizable: true,
-      shadow: false,
+      hasShadow: false,
       enableLargerThanScreen: true,
       x,
       y


### PR DESCRIPTION
Turns out the option there was incorrect: https://electron.atom.io/docs/api/browser-window/