### PR TITLE
Cancel image processing

### DIFF
--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -237,6 +237,7 @@ section.progress {
 
 .progress-bar {
   width: 206px;
+  margin-bottom: 16px;
 }
 
 .progress-bar-label {

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -46,6 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressBar = document.querySelector('#progress-bar');
   const progressBarLabel = document.querySelector('.progress-bar-label');
   const progressBarSection = document.querySelector('section.progress');
+  const progressBarCancelBtn = document.querySelector('.progress-bar-cancel-btn');
   const recordBtn = document.querySelector('.record');
   const restartAndInstallUpdateBtn = document.querySelector('.restart-and-install-update');
   const size = document.querySelector('.size');
@@ -369,6 +370,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   linkBtn.onclick = function () {
     this.classList.toggle('active');
+  };
+
+  progressBarCancelBtn.onclick = function () {
   };
 
   aspectRatioSelector.onchange = function () {

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -15,6 +15,7 @@ block body
   section.progress.hidden
     label.progress-bar-label.txt(for='progress-bar') This might take a moment...
     progress.c-progress#progress-bar.progress-bar(max='100')
+    button.button--secondary.progress-bar-cancel-btn cancel
 
   //- Main App area/header (record button container)
   header.kap-header


### PR DESCRIPTION
**This is a work in progress**

This pr attempts to address #73 :

> Would be very convenient to be able to cancel processing, if I see it's going too slow and obviously will result in a very large gif (162mb, in my case). My macbook's cooling fan was going like crazy :D

Proposed UI change: 

![](https://cloud.githubusercontent.com/assets/3030010/26478442/a40cc536-420f-11e7-9da4-db42cd6a7a07.png)

I would really appreciate some guidance regarding the cancelation logic.
