### PR TITLE
Use the native traffic lights for the Preferences window

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -193,8 +193,10 @@ function openPrefsWindow() {
   prefsWindow = new BrowserWindow({
     width: 480,
     height: 480,
-    frame: false,
     resizable: false,
+    minimizable: false,
+    maximizable: false,
+    titleBarStyle: 'hidden',
     show: false
   });
 

--- a/app/src/renderer/css/preferences.css
+++ b/app/src/renderer/css/preferences.css
@@ -45,6 +45,21 @@ nav.prefs-nav {
   }
 }
 
+/* `window-header` override */
+.window-header .window__title {
+  font-size: 1.3rem !important;
+  line-height: initial !important;
+}
+
+.title-bar {
+  height: 2.4rem !important;
+}
+
+.title-bar__controls {
+  display: none !important;
+}
+/* / `window-header` override */
+
 .prefs-sections {
   overflow-y: auto;
 }


### PR DESCRIPTION
To make it look consistent with other macOS apps.

This also made it easy to disable minimizing the window. Preference windows should not be minimizable on macOS.

## Before

![screen shot 2017-05-29 at 19 05 54](https://cloud.githubusercontent.com/assets/170270/26549491/7c74d14e-44a3-11e7-8fa0-f2f8ffabe683.png)

## After

![screen shot 2017-05-29 at 19 14 03](https://cloud.githubusercontent.com/assets/170270/26549495/7ce2341e-44a3-11e7-8bc8-1fbeeba9c196.png)


