### PR TITLE
Fix share selection index bug

### DIFF
--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -199,9 +199,11 @@ document.addEventListener('DOMContentLoaded', () => {
         if (service.formats.includes(format)) {
           const option = document.createElement('option');
           option.text = service.title;
-          option.value = i++;
+          option.value = i;
           dropdown.appendChild(option);
         }
+
+        i++;
       }
 
       btn.appendChild(dropdown);


### PR DESCRIPTION
When having 3 export selections for GIF like this

1. Save to disk
2. Share to GIPHY
3. Share to X

And 2 for MP4

1. Save to disk
2. Share to X

When selecting `Share to X` in the MP4 dropdown, it will still share it to giphy. This PR solves that.