### PR TITLE
Don't `.show()` the main window if Kap was opened on system startup

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -297,8 +297,8 @@ menubar.on('after-create-window', () => {
       // because of that, we need to move the window to it's expected position, since the
       // user will never release the mouse in the *right* position (diff.[x, y] === 0)
       if (!wasOpenedAtLogin(app)) {
-        // Seems like electorn fires the `move` event right aftet the app boots,
-        // and we don't highlight the tray icon if the compiuter just
+        // Seems like Electron fires the `move` event right after the app boots,
+        // and we don't highlight the tray icon if the computer just
         // booted given that we don't show the window in this case
         tray.setHighlightMode('always');
       }

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -39,6 +39,10 @@ let recording = false;
 
 settings.init();
 
+const wasOpenedAtLogin = app => {
+  return app.getLoginItemSettings().wasOpenedAtLogin;
+};
+
 ipcMain.on('set-main-window-size', (event, args) => {
   if (args.width && args.height && mainWindow) {
     [args.width, args.height] = [parseInt(args.width, 10), parseInt(args.height, 10)];
@@ -294,7 +298,12 @@ menubar.on('after-create-window', () => {
       // The `move` event is called when the user reselases the mouse button
       // because of that, we need to move the window to it's expected position, since the
       // user will never release the mouse in the *right* position (diff.[x, y] === 0)
-      tray.setHighlightMode('always');
+      if (!wasOpenedAtLogin(app)) {
+        // Seems like electorn fires the `move` event right aftet the app boots,
+        // and we don't highlight the tray icon if the compiuter just
+        // booted given that we don't show the window in this case
+        tray.setHighlightMode('always');
+      }
       positioner.move('trayCenter', tray.getBounds());
     } else if (wasStuck) {
       mainWindow.webContents.send('unstick-from-menubar');
@@ -345,7 +354,11 @@ menubar.on('after-create-window', () => {
 
   mainWindow.once('ready-to-show', () => {
     positioner.move('trayCenter', tray.getBounds()); // Not sure why the fuck this is needed (ﾉಠдಠ)ﾉ︵┻━┻
-    mainWindow.show();
+    if (!wasOpenedAtLogin(app)) {
+      // We only want to show the window if the Kap wasn't oepened automatically
+      // after the used logged in
+      mainWindow.show();
+    }
   });
 
   mainWindowIsNew = true;

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -39,9 +39,7 @@ let recording = false;
 
 settings.init();
 
-const wasOpenedAtLogin = app => {
-  return app.getLoginItemSettings().wasOpenedAtLogin;
-};
+const wasOpenedAtLogin = app => app.getLoginItemSettings().wasOpenedAtLogin;
 
 ipcMain.on('set-main-window-size', (event, args) => {
   if (args.width && args.height && mainWindow) {

--- a/scripts/download-ffmpeg.js
+++ b/scripts/download-ffmpeg.js
@@ -9,7 +9,7 @@ const ora = require('ora');
 
 let spinner = ora({text: 'Installing 7zip', stream: process.stdout}).start();
 
-const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-85767-gdec2fa8.7z';
+const FFMPEG_URL = 'https://evermeet.cx/ffmpeg/ffmpeg-86781-gd8f1982.7z';
 const VENDOR_PATH = ['..', 'app', 'vendor'];
 
 const joinPath = (...str) => path.join(__dirname, ...str);


### PR DESCRIPTION
Fixes #208 👌 

Also bumped the `ffmpeg` version since the current one is gone 