### PR TITLE
Disable install/uninstall plugins buttons when working

### DIFF
--- a/app/src/renderer/css/components/_buttons.css
+++ b/app/src/renderer/css/components/_buttons.css
@@ -75,7 +75,7 @@
     &:first-child { border-radius: 4px 0 0 4px; }
     &:last-child { border-radius: 0 4px 4px 0; }
     &:not(:last-child) { border-right: 1px solid #DDD; }
-    &.disabled { pointer-events: none; }
+
     &:hover {
       background: white;
       &:not(:active):not(.is-active) {
@@ -123,13 +123,17 @@
   }
 }
 
+button {
+  &:disabled,
+  &.disabled {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+}
+
 .button--primary {
   background: #3B99FC;
   border-color: #2D91FC;
-}
-
-.button--primary:disabled {
-  opacity: 0.5;
 }
 
 .button--secondary {
@@ -139,6 +143,10 @@
 
   &:hover {
     border-color: $blue;
+  }
+
+  &:disabled {
+    border-color: $gray-light;
   }
 }
 

--- a/app/src/renderer/js/preferences.js
+++ b/app/src/renderer/js/preferences.js
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   $j('#plugins-installed').on('click', '.uninstall', function () {
-    $j(this).prop('disabled', true);
+    $j(this).prop('disabled', true).text('Uninstalling…');
     const name = $j(this).data('name');
 
     (async () => {
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   $j('#plugins-available').on('click', '.install', function () {
-    $j(this).prop('disabled', true);
+    $j(this).prop('disabled', true).text('Installing…');
     const name = $j(this).data('name');
 
     (async () => {


### PR DESCRIPTION
And indicate that it's doing something: 
<img width="142" alt="screen shot 2017-09-17 at 14 59 15" src="https://user-images.githubusercontent.com/170270/30519166-35d97b64-9bb9-11e7-9624-24cf2ba5a479.png">

We can add a fancy animation or maybe even progress info later on, but I think this is good enough for Kap v2.
