### PR TITLE
Make the editor window size inputs be consistent

### DIFF
--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -166,7 +166,11 @@ section.output {
   display: flex;
   align-items: center;
 }
-.size > input + input { margin-left: 6px }
+
+.size input {
+  font-size: 1.2rem;
+  text-align: center;
+}
 
 ul {
   display: flex;


### PR DESCRIPTION
The input text is now the same size as other inputs and centered.

## Before

<img width="880" alt="screen shot 2017-10-27 at 21 15 42" src="https://user-images.githubusercontent.com/170270/32109053-c72183be-bb5d-11e7-8a9d-98932fd79aab.png">

## After

<img width="880" alt="screen shot 2017-10-27 at 21 26 19" src="https://user-images.githubusercontent.com/170270/32109058-ceda4294-bb5d-11e7-88bf-7994810165ac.png">
