### PR TITLE
Fix dragging timeline marker moves window

### DIFF
--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -158,6 +158,7 @@ video {
   height: 100%;
   transform: translateX(-50%);
   top: 6px;
+  -webkit-app-region: no-drag;
 }
 
 section.output {


### PR DESCRIPTION
Fixes #260

Just disables dragging for the whole timeline, which makes sense as we don't want any window dragging there ever.