### PR TITLE
Install and uninstall plugins in the main process

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -582,3 +582,22 @@ ipcMain.on('set-main-window-visibility', (event, opts) => {
     }, opts.forHowLong);
   }
 });
+
+const loadPlugins = async () => {
+  if (prefsWindow) {
+    prefsWindow.webContents.send('load-plugins', {
+      available: await plugins.getFromNpm(),
+      installed: plugins.all()
+    });
+  }
+};
+
+ipcMain.on('install-plugin', async (event, name) => {
+  await plugins.install(name);
+  loadPlugins();
+});
+
+ipcMain.on('uninstall-plugin', async (event, name) => {
+  await plugins.uninstall(name);
+  loadPlugins();
+});


### PR DESCRIPTION
This avoids calling functions in the main process from the renderer if the renderer is closed.

Fixes #257.