### PR TITLE
Add `Discard` button to editor Touch Bar

### DIFF
--- a/app/src/main/touch-bar.js
+++ b/app/src/main/touch-bar.js
@@ -1,7 +1,7 @@
 import {TouchBar} from 'electron';
 import plugins from './plugins';
 
-const {TouchBarButton, TouchBarPopover} = TouchBar;
+const {TouchBarButton, TouchBarPopover, TouchBarSpacer} = TouchBar;
 
 const aspectRatioToSize = new Map([
   ['16:9', '1600x900'],
@@ -104,6 +104,7 @@ export const createEditorTouchbar = ({onDiscard, onSelectPlugin}) => {
 
   return new TouchBar([
     ...formatPopovers,
+    new TouchBarSpacer({size: 'small'}),
     discardButton
   ]);
 };

--- a/app/src/main/touch-bar.js
+++ b/app/src/main/touch-bar.js
@@ -104,7 +104,7 @@ export const createEditorTouchbar = ({onDiscard, onSelectPlugin}) => {
 
   return new TouchBar([
     ...formatPopovers,
-    new TouchBarSpacer({size: 'small'}),
+    new TouchBarSpacer({size: 'large'}),
     discardButton
   ]);
 };

--- a/app/src/main/touch-bar.js
+++ b/app/src/main/touch-bar.js
@@ -104,7 +104,7 @@ export const createEditorTouchbar = ({onDiscard, onSelectPlugin}) => {
 
   return new TouchBar([
     ...formatPopovers,
-    new TouchBarSpacer({size: 'large'}),
+    new TouchBarSpacer({size: 'flexible'}),
     discardButton
   ]);
 };

--- a/app/src/main/touch-bar.js
+++ b/app/src/main/touch-bar.js
@@ -87,8 +87,13 @@ const createFormatPopover = ({format, services, onSelectPlugin}) => {
   });
 };
 
-export const createEditorTouchbar = ({onSelectPlugin}) => {
+export const createEditorTouchbar = ({onDiscard, onSelectPlugin}) => {
   const shareServices = plugins.getShareServicesPerFormat();
+  const discardButton = new TouchBarButton({
+    label: 'Discard',
+    backgroundColor: '#ff5050',
+    click: onDiscard
+  });
   const formatPopovers = Object.keys(shareServices).map(format => {
     return createFormatPopover({
       format,
@@ -97,5 +102,8 @@ export const createEditorTouchbar = ({onSelectPlugin}) => {
     });
   });
 
-  return new TouchBar(formatPopovers);
+  return new TouchBar([
+    ...formatPopovers,
+    discardButton
+  ]);
 };


### PR DESCRIPTION
This partly fixes #246 by adding a "Discard" button to the touch bar. Not 100% sure about the color since it's the same as "Record" which might cause confusion.

<img width="1085" alt="touch bar shot 2017-10-30 at 19 48 40" src="https://user-images.githubusercontent.com/709159/32189897-580ddb66-bdac-11e7-93ef-71fa7002bba3.png">
