### PR TITLE
Fix round corners in editor on macOS 10.13

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -498,7 +498,10 @@ ipcMain.on('open-editor-window', (event, opts) => {
     height: 480,
     minHeight: 480,
     frame: false,
-    vibrancy: 'dark'
+    vibrancy: 'ultra-dark',
+    // The below is: `rgba(0, 0, 0, 0.8)`
+    // Convert tool: https://kilianvalkhof.com/2016/css-html/css-hexadecimal-colors-with-transparency-a-conversion-tool/
+    backgroundColor: '#000000CC'
   });
 
   app.kap.editorWindow = editorWindow;

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -17,7 +17,6 @@
 html { height: 100%; }
 
 body {
-  background-color: rgba(0, 0, 0, .6);
   -webkit-app-region: drag;
   color: white;
   height: 100%;
@@ -35,6 +34,7 @@ main.content {
   flex-direction: column;
   height: 100%;
   background: transparent;
+  border-radius: 5px;
 }
 
 /*


### PR DESCRIPTION
Seems like some kind of Electron bug, as usual. If a background is set on `body`, it overflows the native window round corners...

Fixes #264

Test: https://kap-artifacts.now.sh/fix-editor-border-radius