### PR TITLE
Remove Kap window from recording

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
   "main": "dist/main/index.js",
   "dependencies": {
     "ajv": "^5.1.3",
-    "aperture": "^3.0.0",
+    "aperture": "github:vadimdemedes/aperture#output-start-time",
     "aspectratio": "^2.2.2",
     "delay": "^2.0.0",
     "eightpoint": "0.0.1",

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -209,10 +209,15 @@ const animateIcon = () => new Promise(resolve => {
     setTimeout(() => {
       // If still waiting for recording to start, keep looping the bouncy animation
       if (i === 54 && appState !== 'recording') {
-        i = 0
+        i = 0;
       }
 
-      const number = String(i++).padStart(5, '0')
+      // If recording started and bouncy animation is still going on, skip it
+      if (appState === 'recording' && i < 54) {
+        i = 54;
+      }
+
+      const number = String(i++).padStart(5, '0');
       const filename = `loading_${number}Template.png`;
 
       tray.setImage(path.join(__dirname, '..', '..', 'static', 'menubar-loading', filename));
@@ -232,8 +237,8 @@ const animateIcon = () => new Promise(resolve => {
 
         next();
       }
-    }, interval)
-  }
+    }, interval);
+  };
 
   next();
 });

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -7,6 +7,7 @@ import isDev from 'electron-is-dev';
 import {init as initErrorReporter} from '../common/reporter';
 import logger from '../common/logger';
 import * as settings from '../common/settings-manager';
+import stripVideo from '../scripts/strip';
 
 import {createMainTouchbar, createCropTouchbar, createEditorTouchbar} from './touch-bar';
 import autoUpdater from './auto-updater';
@@ -488,10 +489,12 @@ ipcMain.on('move-cropper-window', (event, data) => {
   cropperWindow.setPosition(...position);
 });
 
-ipcMain.on('open-editor-window', (event, opts) => {
+ipcMain.on('open-editor-window', async (event, opts) => {
   if (editorWindow) {
     return editorWindow.show();
   }
+
+  opts.filePath = await stripVideo(opts.filePath, opts.stripFirstMs);
 
   editorWindow = new BrowserWindow({
     width: 768,

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -65,6 +65,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   handleTrafficLightsClicks({hide: true});
 
+  let stripFirstMs;
+
   async function startRecording() {
     ipcRenderer.send('will-start-recording');
 
@@ -123,7 +125,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     try {
-      await aperture.startRecording(apertureOpts);
+      const clickedAt = Date.now();
+      const {startedAt} = await aperture.startRecording(apertureOpts);
+      stripFirstMs = startedAt - clickedAt;
+
       log(`Started recording after ${(Date.now() - past) / 1000}s`);
     } catch (err) {
       // This prevents the button from being reset, since the recording has not yet started
@@ -144,7 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const filePath = await aperture.stopRecording();
     ipcRenderer.send('stopped-recording');
-    ipcRenderer.send('open-editor-window', {filePath});
+    ipcRenderer.send('open-editor-window', {filePath, stripFirstMs});
     setMainWindowSize();
   }
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -129,6 +129,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const {startedAt} = await aperture.startRecording(apertureOpts);
       stripFirstMs = startedAt - clickedAt;
 
+      ipcRenderer.send('started-recording');
+
       log(`Started recording after ${(Date.now() - past) / 1000}s`);
     } catch (err) {
       // This prevents the button from being reset, since the recording has not yet started

--- a/app/src/scripts/strip.js
+++ b/app/src/scripts/strip.js
@@ -1,0 +1,24 @@
+import {extname, join} from 'path';
+import tempy from 'tempy';
+import execa from 'execa';
+
+const ffmpeg = join(__dirname, '..', '..', 'vendor', 'ffmpeg');
+
+const prependZero = n => n < 10 ? `0${n}` : n;
+
+const ffmpegTime = ms => {
+  const seconds = Math.floor(ms / 1000);
+  const milliseconds = ms - seconds * 1000; // eslint-disable-line no-mixed-operators
+
+  return `00:00:${prependZero(seconds)}.${milliseconds}`;
+};
+
+// Strip first `ms` milliseconds
+module.exports = async (filePath, ms) => {
+  const extension = extname(filePath).slice(1);
+  const strippedPath = tempy.file({extension});
+
+  await execa(ffmpeg, ['-an', '-ss', ffmpegTime(ms), '-i', filePath, '-vcodec', 'libx264', '-pix_fmt', 'yuv420p', '-profile:v', 'baseline', '-level', '3', strippedPath]);
+
+  return strippedPath;
+};

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -65,9 +65,9 @@ ansistyles@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
 
-aperture@^3.0.0:
+"aperture@github:vadimdemedes/aperture#output-start-time":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aperture/-/aperture-3.0.0.tgz#9232b3f995253ad51b991de0315dd307512aee50"
+  resolved "https://codeload.github.com/vadimdemedes/aperture/tar.gz/bb50dc86b6302ee16c8452adeb335ad3c59ebf9e"
   dependencies:
     execa "^0.8.0"
     file-url "^2.0.2"
@@ -432,7 +432,7 @@ debug@^2.2.0:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -929,7 +929,7 @@ iferr@^0.1.5, iferr@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -1170,10 +1170,6 @@ lockfile@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -1181,25 +1177,11 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -1216,10 +1198,6 @@ lodash.debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
   dependencies:
     lodash._getnative "^3.0.0"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.union@~4.6.0:
   version "4.6.0"
@@ -1893,7 +1871,7 @@ readable-stream@~2.2.9:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -2361,7 +2339,7 @@ uuid@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/wulkano/kap/issues/3. Depends on https://github.com/wulkano/aperture/pull/52.

Regarding https://github.com/wulkano/kap/compare/cut-start?expand=1#diff-3ff6aef2849fdd54608f21a77278768aR21, I tried stripping time without re-encoding (`-c copy`), but the produced video wouldn't play in the editor, saying that it's unsupported. If anyone could help with the right ffmpeg command, that'd be awesome!

Although, if we're going to merge https://github.com/wulkano/kap/pull/254, we would need to generate a preview of HEVC anyway, so maybe we can leave this command as-is. Thoughts?