### PR TITLE
Fix saving to an external disk

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "make-dir": "^1.0.0",
     "menubar": "github:matheuss/menubar",
     "moment": "^2.14.1",
+    "move-file": "^0.2.0",
     "ms": "^2.0.0",
     "npm": "^4.6.1",
     "object-path": "^0.11.3",

--- a/app/src/main/save-file-service.js
+++ b/app/src/main/save-file-service.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import {app, dialog} from 'electron';
 import makeDir from 'make-dir';
+import moveFile from 'move-file';
 
 const action = async context => {
   const format = context.format;
@@ -30,7 +30,8 @@ const action = async context => {
     return;
   }
 
-  fs.renameSync(await context.filePath(), filePath);
+  // TODO: Switch to the async version when we target Electron 1.8
+  moveFile.sync(await context.filePath(), filePath);
 };
 
 module.exports = {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -386,6 +386,16 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cp-file@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-5.0.0.tgz#bc700fd30ca32d24d46c7fb02b992e435fc5a978"
+  dependencies:
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    nested-error-stacks "^2.0.0"
+    pify "^3.0.0"
+    safe-buffer "^5.0.1"
+
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -1240,7 +1250,7 @@ macos-version@^4.0.1:
   dependencies:
     semver "^5.3.0"
 
-make-dir@^1.0.0:
+make-dir@^1.0.0, make-dir@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
   dependencies:
@@ -1317,6 +1327,14 @@ move-concurrently@~1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+move-file@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/move-file/-/move-file-0.2.0.tgz#f96c6826ab66d2155bdd69bfd908795327e86faa"
+  dependencies:
+    cp-file "^5.0.0"
+    make-dir "^1.1.0"
+    path-exists "^3.0.0"
+
 ms@2.0.0, ms@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1328,6 +1346,12 @@ mute-stream@0.0.5:
 mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nested-error-stacks@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.0.0.tgz#98b2ffaefb4610fa3936f1e71435d30700de2840"
+  dependencies:
+    inherits "~2.0.1"
 
 node-gyp@~3.6.0:
   version "3.6.2"


### PR DESCRIPTION
Fixes #55

`fs.renameSync` doesn't work across disks.

I've tested this with an external drive and it works.

@radum @gugahoi Can you confirm? Download: https://kap-artifacts.now.sh/save-across-device