### PR TITLE
Notify on plugin install/uninstall success and failure

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import {app, BrowserWindow, ipcMain, Menu, screen, globalShortcut, dialog} from 'electron';
+import {app, BrowserWindow, ipcMain, Menu, screen, globalShortcut, dialog, Notification} from 'electron';
 import isDev from 'electron-is-dev';
 
 import {init as initErrorReporter} from '../common/reporter';
@@ -601,14 +601,29 @@ const loadPlugins = async () => {
   }
 };
 
+const notify = text => {
+  (new Notification({
+    body: text
+  })).show();
+};
+
 ipcMain.on('install-plugin', async (event, name) => {
-  await plugins.install(name);
-  loadPlugins();
+  try {
+    await plugins.install(name);
+    notify(`Successfully installed plugin ${name}`);
+    loadPlugins();
+  } catch (err) {
+    dialog.showErrorBox(`Failed to install plugin ${name}`, err.stderr || err.stdout || err.stack);
+  }
 });
 
 ipcMain.on('uninstall-plugin', async (event, name) => {
-  await plugins.uninstall(name);
-  loadPlugins();
+  try {
+    await plugins.uninstall(name);
+    loadPlugins();
+  } catch (err) {
+    dialog.showErrorBox(`Failed to uninstall plugin ${name}`, err.stderr || err.stdout || err.stack);
+  }
 });
 
 ipcMain.on('toggle-play', (event, status) => {

--- a/app/src/main/plugins.js
+++ b/app/src/main/plugins.js
@@ -50,13 +50,7 @@ class Plugins {
     pkg.dependencies[name] = 'latest';
     fs.writeFileSync(pkgPath, JSON.stringify(pkg));
 
-    try {
-      await this.upgrade();
-    } catch (err) {
-      console.error(err);
-      console.error(err.stderr);
-      console.error(err.stdout);
-    }
+    await this.upgrade();
   }
 
   async uninstall(name) {


### PR DESCRIPTION
![screen shot 2017-11-07 at 01 48 05](https://user-images.githubusercontent.com/170270/32458318-a61dc16a-c35e-11e7-82ec-e70032fbacc4.png)

I deliberately didn't add a notification on uninstall, as I don't see that being useful, and I also plan on making uninstalling a plugin instant.

---

You can try it out here: https://kap-artifacts.now.sh/plugin-notifications