### PR TITLE
Enable ASAR

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
   "main": "dist/main/index.js",
   "dependencies": {
     "ajv": "^5.1.3",
-    "aperture": "^3.0.0",
+    "aperture": "^4.0.0",
     "aspectratio": "^2.2.2",
     "delay": "^2.0.0",
     "eightpoint": "0.0.1",

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -5,7 +5,7 @@ import execa from 'execa';
 import moment from 'moment';
 import tmp from 'tmp';
 
-const ffmpeg = joinPath(__dirname, '..', '..', 'vendor', 'ffmpeg');
+const ffmpeg = joinPath(__dirname.replace('app.asar', 'app.asar.unpacked'), '..', '..', 'vendor', 'ffmpeg');
 const durationRegex = /Duration: (\d\d:\d\d:\d\d.\d\d)/gm;
 const frameRegex = /frame=\s+(\d+)/gm;
 

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -65,9 +65,9 @@ ansistyles@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
 
-aperture@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aperture/-/aperture-3.0.0.tgz#9232b3f995253ad51b991de0315dd307512aee50"
+aperture@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/aperture/-/aperture-4.0.0.tgz#7d2b47d645e7ff99d9b4196397cd9e59bdb4ad22"
   dependencies:
     execa "^0.8.0"
     file-url "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -75,12 +75,14 @@
     }
   },
   "build": {
-    "asar": false,
     "appId": "com.wulkano.kap",
     "files": [
       "**/*",
       "dist",
       "!src"
+    ],
+    "asarUnpack": [
+      "vendor/ffmpeg"
     ],
     "mac": {
       "category": "public.app-category.productivity"


### PR DESCRIPTION
At last ✨

Fixes #103 

I had to do some changes in Aperture too: https://github.com/wulkano/aperture/commit/af5b72dc238b2f3e2ab2f233494e19969c6d8ccc

Unpacking the binaries changes the filesystem path, but doesn't update `__dirname`, so we need to do that manually... Relevant Electron issue: https://github.com/electron/electron/issues/8206

Please help test: https://kap-artifacts.now.sh/enable-asar