### PR TITLE
Add no-drag to video controls

### DIFF
--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -57,33 +57,33 @@ main.content {
   justify-content: center;
   background: $black;
 
-  /* &:hover { */
-  .video-controls {
-    background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
-  }
+  &:hover {
+    .video-controls {
+      background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
+    }
 
-  .video-controls-right,
-  .video-controls-left,
-  .timeline-markers {
-    opacity: 1;
-  }
+    .video-controls-right,
+    .video-controls-left,
+    .timeline-markers {
+      opacity: 1;
+    }
 
-  .c-progress.editor-progress {
-    width: 60%;
-    border-radius: 4px;
-    bottom: 26px;
-    left: 50%;
-    transform: translateX(-50%);
-  }
+    .c-progress.editor-progress {
+      width: 60%;
+      border-radius: 4px;
+      bottom: 26px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
 
-  .timeline-markers {
-    width: 60%;
-    height: 16px;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
+    .timeline-markers {
+      width: 60%;
+      height: 16px;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
   }
-  /* } */
 }
 
 .video-controls {
@@ -184,7 +184,7 @@ video {
 }
 
 .timeline-container:hover .timeline-markers .slider::-webkit-slider-thumb {
-  width: 5px;
+  width: 4px;
   height: 16px;
 }
 

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -57,33 +57,33 @@ main.content {
   justify-content: center;
   background: $black;
 
-  &:hover {
-    .video-controls {
-      background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
-    }
-
-    .video-controls-right,
-    .video-controls-left,
-    .timeline-markers {
-      opacity: 1;
-    }
-
-    .c-progress.editor-progress {
-      width: 60%;
-      border-radius: 4px;
-      bottom: 26px;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-
-    .timeline-markers {
-      width: 60%;
-      height: 16px;
-      bottom: 20px;
-      left: 50%;
-      transform: translateX(-50%);
-    }
+  /* &:hover { */
+  .video-controls {
+    background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
   }
+
+  .video-controls-right,
+  .video-controls-left,
+  .timeline-markers {
+    opacity: 1;
+  }
+
+  .c-progress.editor-progress {
+    width: 60%;
+    border-radius: 4px;
+    bottom: 26px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .timeline-markers {
+    width: 60%;
+    height: 16px;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  /* } */
 }
 
 .video-controls {
@@ -99,6 +99,8 @@ main.content {
   background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 100%, rgba(0, 0, 0, 0.2) 100%);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   transition: background 0.12s ease-in-out;
+
+   /* !important because electron's app-region behavior is odd */
   -webkit-app-region: no-drag !important;
 
   &-right,
@@ -182,7 +184,7 @@ video {
 }
 
 .timeline-container:hover .timeline-markers .slider::-webkit-slider-thumb {
-  width: 4px;
+  width: 5px;
   height: 16px;
 }
 

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -99,6 +99,7 @@ main.content {
   background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 100%, rgba(0, 0, 0, 0.2) 100%);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   transition: background 0.12s ease-in-out;
+  -webkit-app-region: no-drag !important;
 
   &-right,
   &-left {
@@ -193,7 +194,6 @@ video {
   left: 0;
   opacity: 0;
   transition: 0.12s ease-in-out;
-  -webkit-app-region: no-drag;
 }
 
 section.output {

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -100,7 +100,7 @@ main.content {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   transition: background 0.12s ease-in-out;
 
-   /* !important because electron's app-region behavior is odd */
+  /* !important because electron's app-region behavior is odd */
   -webkit-app-region: no-drag !important;
 
   &-right,


### PR DESCRIPTION
Since `-webkit-app-region: drag` is added to `body`, we need to add `!important` to the selector where we want the behavior to change.