### PR TITLE
Ratio selector improvements

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.14.1",
     "move-file": "^0.2.0",
     "ms": "^2.0.0",
-    "node-mac-app-icon": "^1.0.1",
+    "node-mac-app-icon": "^1.1.0",
     "npm": "^4.6.1",
     "object-path": "^0.11.3",
     "raven": "^2.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -39,6 +39,7 @@
     "moment": "^2.14.1",
     "move-file": "^0.2.0",
     "ms": "^2.0.0",
+    "node-mac-app-icon": "^1.0.1",
     "npm": "^4.6.1",
     "object-path": "^0.11.3",
     "raven": "^2.3.0",

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -32,7 +32,7 @@ const menubar = require('menubar')({
 
 let appState = 'initial';
 let cropperWindow;
-const cropperWindowBuffer = 0;
+const cropperWindowBuffer = 2;
 let mainWindowIsDetached = false;
 let mainWindow;
 let mainWindowIsNew = true;

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -405,6 +405,10 @@ menubar.on('after-create-window', () => {
     }
   });
 
+  mainWindow.on('show', () => {
+    mainWindow.webContents.send('reload-apps');
+  });
+
   menubar.on('show', () => {
     if (mainWindowIsDetached) {
       tray.setHighlightMode('never');

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -181,7 +181,7 @@ const openCropperWindow = (size = {}, position = {}) => {
   }
 };
 
-ipcMain.on('activate-application', async (event, appName, {width, height, x, y}) => {
+ipcMain.on('activate-app', async (event, appName, {width, height, x, y}) => {
   if (cropperWindow) {
     cropperWindow.close();
   }

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -405,10 +405,6 @@ menubar.on('after-create-window', () => {
     }
   });
 
-  mainWindow.on('show', () => {
-    mainWindow.webContents.send('load-apps');
-  });
-
   menubar.on('show', () => {
     if (mainWindowIsDetached) {
       tray.setHighlightMode('never');

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -32,7 +32,7 @@ const menubar = require('menubar')({
 
 let appState = 'initial';
 let cropperWindow;
-const cropperWindowBuffer = 2;
+const cropperWindowBuffer = 0;
 let mainWindowIsDetached = false;
 let mainWindow;
 let mainWindowIsNew = true;

--- a/app/src/renderer/css/components/_inputs.css
+++ b/app/src/renderer/css/components/_inputs.css
@@ -37,7 +37,12 @@ input {
     border-color: $gray-dark;
   }
 
-  select {
+  button {
+    text-align: left;
+  }
+
+  select,
+  button {
     width: 100%;
     height: 2.4rem;
     padding-right: 12px;
@@ -55,8 +60,12 @@ input {
   &--large {
     height: 3.2rem;
 
-    select {
+    select,
+    button {
       height: 3.2rem;
+    }
+
+    select {
       line-height: 3.2rem;
     }
   }
@@ -71,7 +80,8 @@ input {
   }
 
   &.has-icon {
-    select {
+    select,
+    button {
       padding-left: 32px;
     }
 

--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -239,10 +239,6 @@ body.is-tray-arrow-hidden {
 
 
 /* Aspect ratio controls */
-.aspect-ratio-select {
-  margin-right: 10px;
-}
-
 .aspect-ratio {
   align-items: flex-end;
   justify-content: space-between;

--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -240,9 +240,12 @@ body.is-tray-arrow-hidden {
 
 /* Aspect ratio controls */
 .ratio-selector .app-logo {
-  display: inline-block;
-  margin-right: 3px;
-  vertical-align: -3px;
+  position: absolute;
+  top: 50%;
+  left: 9px;
+  transform: translateY(-50%);
+  background-color: #fff;
+  box-shadow: 0 0 0 3px #fff;
 }
 
 .aspect-ratio {

--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -239,6 +239,12 @@ body.is-tray-arrow-hidden {
 
 
 /* Aspect ratio controls */
+.ratio-selector .app-logo {
+  display: inline-block;
+  margin-right: 3px;
+  vertical-align: -3px;
+}
+
 .aspect-ratio {
   align-items: flex-end;
   justify-content: space-between;

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -1,5 +1,5 @@
 import {ipcRenderer, remote} from 'electron';
-import {EventEmitter} from 'events';
+import EventEmitter from 'events';
 
 import {init as initErrorReporter, report as reportError} from '../../common/reporter';
 import {log} from '../../common/logger';

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -361,6 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ipcRenderer.on('cropper-window-new-size', (event, size) => {
     if (inputWidth !== document.activeElement && inputHeight !== document.activeElement) {
       [inputWidth.value, inputHeight.value] = [size.width, size.height];
+      setSelectedRatio(size.width, size.height);
     }
   });
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -386,8 +386,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   ipcRenderer.on('cropper-window-new-size', (event, size) => {
     if (inputWidth !== document.activeElement && inputHeight !== document.activeElement) {
-      [inputWidth.value, inputHeight.value] = [size.width, size.height];
-      setSelectedRatio(size.width, size.height);
+      const width = size.width - app.kap.cropperWindowBuffer;
+      const height = size.height - app.kap.cropperWindowBuffer;
+      [inputWidth.value, inputHeight.value] = [width, height];
+      setSelectedRatio(width, height);
     }
   });
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -328,11 +328,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // eg. for showing app name after selection
     dimensions.app = {
       pid: app.pid,
+      fullscreen: app.fullscreen,
       width: app.width,
       height: app.height
     };
 
-    if (app.pid < 0) {
+    if (app.fullscreen) {
       // Fullscreen
       ipcRenderer.send('open-cropper-window', {width: app.width, height: app.height}, {x: 1, y: 1});
     } else {
@@ -375,9 +376,12 @@ document.addEventListener('DOMContentLoaded', () => {
     recordBtn.dataset.state = 'initial';
   });
 
-  ipcRenderer.on('cropper-window-opened', () => {
+  ipcRenderer.on('cropper-window-opened', (event, bounds) => {
     recordBtn.classList.add('is-cropping');
     recordBtn.dataset.state = 'ready-to-record';
+
+    [inputWidth.value, inputHeight.value] = [bounds.width, bounds.height];
+    setSelectedRatio(bounds.width, bounds.height);
   });
 
   ipcRenderer.on('cropper-window-new-size', (event, size) => {

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -177,6 +177,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function setSelectedRatio(width, height) {
+    width = parseFloat(width);
+    height = parseFloat(height);
     dimensions.ratio = findRatioForSize(width, height);
     dimensionsEmitter.emit('change', dimensions);
     app.kap.settings.set('dimensions', dimensions);

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -328,12 +328,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // eg. for showing app name after selection
     dimensions.app = {
       pid: app.pid,
-      fullscreen: app.fullscreen,
+      isFullscreen: app.isFullscreen,
       width: app.width,
       height: app.height
     };
 
-    if (app.fullscreen) {
+    if (app.isFullscreen) {
       // Fullscreen
       ipcRenderer.send('open-cropper-window', {width: app.width, height: app.height}, {x: 1, y: 1});
     } else {

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -311,6 +311,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const handleSizeChange = function (ratio) {
+    dimensions.app = null;
     dimensions.ratio = [parseInt(ratio.split(':')[0], 10), parseInt(ratio.split(':')[1], 10)];
 
     dimensions.ratioLocked = true;

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -7,7 +7,7 @@ import {log} from '../../common/logger';
 // Note: `./` == `/app/dist/renderer/views`, not `js`
 import {handleKeyDown, validateNumericInput} from '../js/input-utils';
 import {handleTrafficLightsClicks, isVisible, disposeObservers} from '../js/utils';
-import buildSizeMenu, { findRatioForSize } from '../js/size-selector';
+import buildSizeMenu, {findRatioForSize} from '../js/size-selector';
 
 const aperture = require('aperture')();
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -177,8 +177,11 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function setSelectedRatio(width, height) {
-    width = parseFloat(width);
-    height = parseFloat(height);
+    // The width and height inputs are not producing whole numbers
+    // sometimes they put out strings, sometimes floats and sometimes ints.
+    // parseInt is used here so the ratio calculation doesn't die.
+    width = parseInt(width, 10);
+    height = parseInt(height, 10);
     dimensions.ratio = findRatioForSize(width, height);
     dimensionsEmitter.emit('change', dimensions);
     app.kap.settings.set('dimensions', dimensions);

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -384,8 +384,6 @@ document.addEventListener('DOMContentLoaded', () => {
     recordBtn.classList.add('is-cropping');
     recordBtn.dataset.state = 'ready-to-record';
 
-    console.log('GOT BOUNDS', bounds);
-
     [inputWidth.value, inputHeight.value] = [bounds.width, bounds.height];
     setSelectedRatio(bounds.width, bounds.height);
   });

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -24,7 +24,7 @@ function setMainWindowSize() {
 
 document.addEventListener('DOMContentLoaded', () => {
   // Element definitions
-  const customSelect = document.querySelector('.custom-select');
+  const ratioSelector = document.querySelector('.ratio-selector');
   const startBar = document.querySelector('.start-bar');
   const controls = document.querySelector('.controls-content');
   const inputWidth = document.querySelector('#aspect-ratio-width');
@@ -308,11 +308,12 @@ document.addEventListener('DOMContentLoaded', () => {
       dimensions.height = (dimensions.ratio[1] / dimensions.ratio[0]) * dimensions.width;
       inputHeight.value = Math.round(dimensions.height);
     }
+    dimensionsEmitter.emit('change', dimensions);
     app.kap.settings.set('dimensions', dimensions);
   };
 
   buildSizeMenu({
-    el: customSelect,
+    el: ratioSelector,
     onRatioChange: handleSizeChange,
     emitter: dimensionsEmitter,
     dimensions

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -184,7 +184,7 @@ document.addEventListener('DOMContentLoaded', () => {
     height = parseInt(height, 10);
     dimensions.ratio = findRatioForSize(width, height);
 
-    // Remove pid from dimensions object
+    // Remove app from dimensions object
     // since size is being set manually
     if (dimensions.app && (dimensions.app.width !== width || dimensions.app.height !== height)) {
       dimensions.app = null;

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -234,6 +234,7 @@ document.addEventListener('DOMContentLoaded', () => {
       dimensions.height = Math.round((second / first) * this.value);
       app.kap.settings.set('dimensions', dimensions);
       inputHeight.value = dimensions.height;
+      lastValidInputHeight = dimensions.height;
     } else {
       setSelectedRatio(dimensions.width, dimensions.height);
     }
@@ -260,6 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
       dimensions.width = Math.round((first / second) * this.value);
       app.kap.settings.set('dimensions', dimensions);
       inputWidth.value = dimensions.width;
+      lastValidInputWidth = dimensions.width;
     } else {
       setSelectedRatio(dimensions.width, dimensions.height);
     }

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -7,7 +7,7 @@ import {log} from '../../common/logger';
 // Note: `./` == `/app/dist/renderer/views`, not `js`
 import {handleKeyDown, validateNumericInput} from '../js/input-utils';
 import {handleTrafficLightsClicks, isVisible, disposeObservers} from '../js/utils';
-import {buildSizeMenu} from '../js/size-selector';
+import buildSizeMenu from '../js/size-selector';
 
 const aperture = require('aperture')();
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -198,7 +198,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function setSelectedRatio(width, height) {
-    console.log('should call');
     ratioChangeEmitter.emit('change', {width, height});
     const ratios = document.querySelectorAll('.aspect-ratio-selector option');
     let hadMatch = false;
@@ -355,7 +354,12 @@ document.addEventListener('DOMContentLoaded', () => {
     app.kap.settings.set('dimensions', dimensions);
   };
 
-  buildSizeMenu(customSelect, handleSizeChange, ratioChangeEmitter);
+  buildSizeMenu({
+    el: customSelect,
+    onRatioChange: handleSizeChange,
+    emitter: ratioChangeEmitter,
+    dimensions
+  });
 
   ipcRenderer.on('change-aspect-ratio', (e, aspectRatio) => handleSizeChange(aspectRatio));
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -44,11 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const trayTriangle = document.querySelector('.tray-arrow');
   const windowHeader = document.querySelector('.window-header');
 
-  buildSizeMenu().then(menu => {
-    customSelect.onclick = event => {
-      menu.popup();
-    }
-  });
+  buildSizeMenu(customSelect);
 
   const [micOnIcon, micOffIcon] = toggleAudioRecordBtn.children;
 

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -44,8 +44,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const trayTriangle = document.querySelector('.tray-arrow');
   const windowHeader = document.querySelector('.window-header');
 
-  buildSizeMenu(customSelect);
-
   const [micOnIcon, micOffIcon] = toggleAudioRecordBtn.children;
 
   const createOption = (label, {disabled = false} = {}) => {
@@ -410,9 +408,9 @@ document.addEventListener('DOMContentLoaded', () => {
     app.kap.settings.set('dimensions', dimensions);
   };
 
-  const handleSizeChange = function () {
+  const handleSizeChange = function (ratio) {
     clearApp();
-    dimensions.ratio = [parseInt(this.value.split(':')[0], 10), parseInt(this.value.split(':')[1], 10)];
+    dimensions.ratio = [parseInt(ratio.split(':')[0], 10), parseInt(ratio.split(':')[1], 10)];
 
     dimensions.ratioLocked = true;
     linkBtn.classList.add('is-active');
@@ -424,12 +422,9 @@ document.addEventListener('DOMContentLoaded', () => {
     app.kap.settings.set('dimensions', dimensions);
   };
 
-  aspectRatioSelector.addEventListener('change', handleSizeChange);
+  buildSizeMenu(customSelect, handleSizeChange);
 
-  ipcRenderer.on('change-aspect-ratio', (e, aspectRatio) => {
-    aspectRatioSelector.value = aspectRatio;
-    handleSizeChange.call(aspectRatioSelector);
-  });
+  ipcRenderer.on('change-aspect-ratio', (e, aspectRatio) => handleSizeChange(aspectRatio));
 
   toggleAudioRecordBtn.onclick = function () {
     micOnIcon.classList.toggle('hidden');

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -7,6 +7,7 @@ import {log} from '../../common/logger';
 // Note: `./` == `/app/dist/renderer/views`, not `js`
 import {handleKeyDown, validateNumericInput} from '../js/input-utils';
 import {handleTrafficLightsClicks, isVisible, disposeObservers} from '../js/utils';
+import {buildSizeMenu} from '../js/size-selector';
 
 const aperture = require('aperture')();
 
@@ -25,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // Element definitions
   const aspectRatioSelector = document.querySelector('.aspect-ratio-selector');
   const appSelector = document.querySelector('.app-selector');
+  const customSelect = document.querySelector('.custom-select');
   const disabledAppOption = appSelector.querySelector('option[disabled]');
   const startBar = document.querySelector('.start-bar');
   const controls = document.querySelector('.controls-content');
@@ -41,6 +43,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const trafficLightsWrapper = document.querySelector('.title-bar__controls');
   const trayTriangle = document.querySelector('.tray-arrow');
   const windowHeader = document.querySelector('.window-header');
+
+  buildSizeMenu().then(menu => {
+    customSelect.onclick = event => {
+      menu.popup();
+    }
+  });
 
   const [micOnIcon, micOffIcon] = toggleAudioRecordBtn.children;
 

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron';
+import {remote, ipcRenderer} from 'electron';
 import {getWindows} from 'mac-windows';
 import {getAppIconListByPid} from 'node-mac-app-icon';
 
@@ -21,35 +21,55 @@ async function getWindowList() {
     size: 16,
     encoding: 'buffer'
   });
-  return windows
-    .filter(win => win.ownerName !== 'Kap')
-    .map(win => Object.assign({}, win, {
-      icon: nativeImage
-        .createFromBuffer(images.find(img => img.pid === win.pid).icon)
-        .resize({
-          width: 16,
-          height: 16
-        })
-    }));
+  const {width, height} = remote.screen.getPrimaryDisplay().bounds;
+
+  return [
+    {
+      ownerName: 'Fullscreen',
+      fullscreen: true,
+      width,
+      height
+    },
+    ...windows
+      .filter(win => win.ownerName !== 'Kap')
+      .map(win => Object.assign({}, win, {
+        icon: nativeImage
+          .createFromBuffer(images.find(img => img.pid === win.pid).icon)
+          .resize({
+            width: 16,
+            height: 16
+          })
+      }))
+  ];
 }
 
-function handleClick(menuItem, el) {
-  el.innerHTML = menuItem.label;
+function handleRatioChange(ratio, el, onRatioChange) {
+  onRatioChange(ratio);
+  el.querySelector('.selector-content').innerHTML = ratio;
 }
 
-export default async function buildSizeMenu(el, handleRatioChange) {
-  const windows = await getWindowList();
+function handleAppChange(app) {
+  if (app.fullscreen) {
+    ipcRenderer.send('open-cropper-window', {width: app.width, height: app.height}, {x: 1, y: 1});
+  } else {
+    ipcRenderer.send('activate-application', app.ownerName, app);
+  }
+}
+
+export default async function buildSizeMenu(el, onRatioChange, emitter) {
+  const [fullscreen, ...windows] = await getWindowList();
   console.log(windows);
+  console.log(emitter);
+  emitter.on('change', e => {
+    console.log('Change', e);
+  });
 
   const menu = Menu.buildFromTemplate([
     ...RATIOS.map(ratio => ({
       label: ratio,
       checked: ratio === DEFAULT_RATIO,
       type: 'radio',
-      click: menuItem => {
-        handleRatioChange(menuItem.label);
-        handleClick(menuItem, el);
-      }
+      click: () => handleRatioChange(ratio, el, onRatioChange)
     })),
     {
       type: 'separator'
@@ -58,7 +78,8 @@ export default async function buildSizeMenu(el, handleRatioChange) {
       label: 'Windows',
       submenu: [
         {
-          label: 'Fullscreen'
+          label: 'Fullscreen',
+          click: () => handleAppChange(fullscreen, el)
         },
         {
           type: 'separator'
@@ -66,7 +87,7 @@ export default async function buildSizeMenu(el, handleRatioChange) {
         ...windows.map(win => ({
           label: win.ownerName,
           icon: win.icon,
-          click: menuItem => handleClick(menuItem, el)
+          click: () => handleAppChange(win)
         }))
       ]
     }

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -131,13 +131,23 @@ export function findRatioForSize(width, height) {
 }
 
 export default async function buildSizeMenu(options) {
-  const {emitter, dimensions, el} = options;
-  const windowList = await getWindowList();
-
+  const {emitter, el} = options;
+  let {dimensions} = options;
+  let windowList = await getWindowList();
   let menu = buildMenuItems(options, dimensions, windowList);
 
+  const rebuild = () => {
+    menu = buildMenuItems(options, dimensions, windowList);
+  };
+
   emitter.on('change', newDimensions => {
-    menu = buildMenuItems(options, newDimensions, windowList);
+    dimensions = newDimensions;
+    rebuild();
+  });
+
+  ipcRenderer.on('reload-apps', async () => {
+    windowList = await getWindowList();
+    rebuild();
   });
 
   el.onclick = () => {

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -42,7 +42,7 @@ async function getWindowList() {
 }
 
 function updateContent(el, ratio) {
-  el.querySelector('.selector-content').innerHTML = ratio || 'Custom';
+  el.querySelector('button').innerHTML = ratio || 'Custom';
 }
 
 function handleAppChange(app) {

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -41,9 +41,8 @@ async function getWindowList() {
   ];
 }
 
-function updateContent(el, currentRatio) {
+function updateContent(el, knownRatio, currentRatio) {
   currentRatio = currentRatio.join(':');
-  const knownRatio = RATIOS.find(ratio => ratio === currentRatio);
   el.querySelector('button').innerHTML = knownRatio || `Custom (${currentRatio})`;
 }
 
@@ -58,8 +57,9 @@ function handleAppChange(app) {
 function buildMenuItems(options, currentDimensions, windowList) {
   const {onRatioChange, el} = options;
   const [fullscreen, ...windows] = windowList;
+  const knownRatio = RATIOS.find(ratio => ratio === currentDimensions.ratio.join(':'));
 
-  updateContent(el, currentDimensions.ratio);
+  updateContent(el, knownRatio, currentDimensions.ratio);
 
   return Menu.buildFromTemplate([
     {
@@ -79,15 +79,23 @@ function buildMenuItems(options, currentDimensions, windowList) {
     },
     ...RATIOS.map(ratio => ({
       label: ratio,
-      checked: ratio === currentDimensions.ratio.join(':'),
+      checked: ratio === knownRatio,
       type: 'radio',
       click: () => onRatioChange(ratio)
-    }))
+    })),
+    {
+      label: 'Custom',
+      enabled: false,
+      type: 'radio',
+      checked: !knownRatio
+    }
   ]);
 }
 
 function sizeMatchesRatio(width, height, ratio) {
   const [first, second] = ratio.split(':');
+  width = parseInt(width, 10);
+  height = parseInt(height, 10);
   return (width / first === height / second);
 }
 

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -62,8 +62,11 @@ function getAppDisplayName(app) {
 function updateContent(el, dimensions, windowList) {
   const content = el.querySelector('button');
   if (dimensions.app) {
-    content.innerHTML = getAppDisplayName(windowList.find(app => app.pid === dimensions.app.pid));
-    return;
+    const app = windowList.find(win => win.pid === dimensions.app.pid);
+    if (app) {
+      content.innerHTML = getAppDisplayName(app);
+      return;
+    }
   }
 
   const stringRatio = dimensions.ratio.join(':');

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -37,7 +37,7 @@ function handleClick(menuItem, el) {
   el.innerHTML = menuItem.label;
 }
 
-export default async function buildSizeMenu(el) {
+export default async function buildSizeMenu(el, handleRatioChange) {
   const windows = await getWindowList();
   console.log(windows);
 
@@ -46,7 +46,10 @@ export default async function buildSizeMenu(el) {
       label: ratio,
       checked: ratio === DEFAULT_RATIO,
       type: 'radio',
-      click: menuItem => handleClick(menuItem, el)
+      click: menuItem => {
+        handleRatioChange(menuItem.label);
+        handleClick(menuItem, el)
+      }
     })),
     {
       type: 'separator'

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -115,7 +115,7 @@ function buildMenuItems(options, currentDimensions, windowList) {
     ...RATIOS.map(ratio => ({
       label: ratio,
       checked: ratio === knownRatio,
-      type: 'radio',
+      type: 'checkbox',
       click: () => {
         emitter.emit('ratio-selected', ratio);
       }
@@ -123,8 +123,8 @@ function buildMenuItems(options, currentDimensions, windowList) {
     {
       label: 'Custom',
       enabled: false,
-      type: 'radio',
-      checked: !knownRatio
+      type: 'checkbox',
+      checked: !knownRatio && !currentDimensions.app
     }
   ]);
 }

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -114,6 +114,8 @@ function getLargestCommonDivisor(first, second) {
 }
 
 function getSimplestRatio(width, height) {
+  width = parseInt(width, 10);
+  height = parseInt(height, 10);
   const lcd = getLargestCommonDivisor(width, height);
   const denominator = width / lcd;
   const numerator = height / lcd;

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -78,7 +78,6 @@ function isAppSelected(dimensions, app) {
   if (!dimensions.app) {
     return false;
   }
-  console.log(dimensions.app.pid, app.pid);
   return dimensions.app.pid === app.pid;
 }
 

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -30,15 +30,20 @@ async function getWindowList() {
     }));
 }
 
-export async function buildSizeMenu() {
+function handleClick(menuItem, el) {
+  el.innerHTML = menuItem.label;
+}
+
+export async function buildSizeMenu(el) {
   const windows = await getWindowList();
   console.log(windows);
 
-  return Menu.buildFromTemplate([
+  const menu = Menu.buildFromTemplate([
     ...RATIOS.map(ratio => ({
       label: ratio,
       checked: ratio === DEFAULT_RATIO,
-      type: 'radio'
+      type: 'radio',
+      click: menuItem => handleClick(menuItem, el)
     })),
     {
       type: 'separator'
@@ -54,9 +59,14 @@ export async function buildSizeMenu() {
         },
         ...windows.map(win => ({
           label: win.ownerName,
-          icon: win.icon
+          icon: win.icon,
+          click: menuItem => handleClick(menuItem, el)
         }))
       ]
     }
   ]);
+
+  el.onclick = event => {
+    menu.popup();
+  };
 }

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -17,12 +17,15 @@ const DEFAULT_RATIO = '1:1';
 
 async function getWindowList() {
   const windows = await getWindows();
-  const images = await getAppIconListByPid(windows.map(win => win.pid), 16);
+  const images = await getAppIconListByPid(windows.map(win => win.pid), {
+    size: 16,
+    encoding: 'buffer'
+  });
   return windows
     .filter(win => win.ownerName !== 'Kap')
     .map(win => Object.assign({}, win, {
       icon: nativeImage
-        .createFromDataURL(images.find(img => img.pid === win.pid).icon)
+        .createFromBuffer(images.find(img => img.pid === win.pid).icon)
         .resize({
           width: 16,
           height: 16

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -34,7 +34,7 @@ function handleClick(menuItem, el) {
   el.innerHTML = menuItem.label;
 }
 
-export async function buildSizeMenu(el) {
+export default async function buildSizeMenu(el) {
   const windows = await getWindowList();
   console.log(windows);
 
@@ -66,7 +66,7 @@ export async function buildSizeMenu(el) {
     }
   ]);
 
-  el.onclick = event => {
+  el.onclick = () => {
     menu.popup();
   };
 }

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -71,7 +71,7 @@ function updateContent(el, dimensions, windowList) {
 
   const stringRatio = dimensions.ratio.join(':');
   const knownRatio = RATIOS.find(ratio => ratio === stringRatio);
-  content.innerHTML = knownRatio || `Custom (${stringRatio})`;
+  content.textContent = knownRatio || `Custom (${stringRatio})`;
 }
 
 function isAppSelected(dimensions, app) {
@@ -131,7 +131,7 @@ function buildMenuItems(options, currentDimensions, windowList) {
 
 function sizeMatchesRatio(width, height, ratio) {
   const [first, second] = ratio.split(':');
-  return (width / first === height / second);
+  return width / first === height / second;
 }
 
 // Helper function for retrieving the simplest ratio,
@@ -165,10 +165,16 @@ export function findRatioForSize(width, height) {
 
 export default async function buildSizeMenu(options) {
   const {emitter, el} = options;
-  const {left: menuX, top: menuY} = el.getBoundingClientRect();
   let {dimensions} = options;
   let windowList = await getWindowList();
   let menu = buildMenuItems(options, dimensions, windowList);
+
+  // Hardcoding 140, because `menu`'s width is not known
+  // and there is no way for electorn menus' to be positioned
+  // from the right
+  const rect = el.getBoundingClientRect();
+  const menuX = rect.left + rect.width - 140;
+  const menuY = rect.top;
 
   const rebuild = () => {
     menu = buildMenuItems(options, dimensions, windowList);

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -48,7 +48,7 @@ export default async function buildSizeMenu(el, handleRatioChange) {
       type: 'radio',
       click: menuItem => {
         handleRatioChange(menuItem.label);
-        handleClick(menuItem, el)
+        handleClick(menuItem, el);
       }
     })),
     {

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -24,7 +24,7 @@ async function getWindowList() {
   return [
     {
       ownerName: 'Fullscreen',
-      pid: -10,
+      fullscreen: true,
       width,
       height
     },
@@ -33,6 +33,7 @@ async function getWindowList() {
       .map(win => {
         const icon = nativeImage.createFromBuffer(images.find(img => img.pid === win.pid).icon);
         return Object.assign({}, win, {
+          fullscreen: false,
           icon2x: icon,
           icon: icon.resize({
             width: 16,
@@ -81,6 +82,13 @@ function isAppSelected(dimensions, app) {
   return dimensions.app.pid === app.pid;
 }
 
+function isFullscreenSelected(dimensions) {
+  if (!dimensions.app) {
+    return false;
+  }
+  return dimensions.app.fullscreen;
+}
+
 function buildMenuItems(options, currentDimensions, windowList) {
   const {emitter, el} = options;
   const [fullscreen, ...windows] = windowList;
@@ -104,7 +112,7 @@ function buildMenuItems(options, currentDimensions, windowList) {
     {
       label: 'Fullscreen',
       type: 'checkbox',
-      checked: isAppSelected(currentDimensions, fullscreen),
+      checked: isFullscreenSelected(currentDimensions, fullscreen),
       click: () => {
         emitter.emit('app-selected', fullscreen);
       }

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -50,7 +50,7 @@ function handleAppChange(app) {
   if (app.fullscreen) {
     ipcRenderer.send('open-cropper-window', {width: app.width, height: app.height}, {x: 1, y: 1});
   } else {
-    ipcRenderer.send('activate-application', app.ownerName, app);
+    ipcRenderer.send('activate-app', app.ownerName, app);
   }
 }
 

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -24,7 +24,7 @@ async function getWindowList() {
   return [
     {
       ownerName: 'Fullscreen',
-      fullscreen: true,
+      isFullscreen: true,
       width,
       height
     },
@@ -33,7 +33,7 @@ async function getWindowList() {
       .map(win => {
         const icon = nativeImage.createFromBuffer(images.find(img => img.pid === win.pid).icon);
         return Object.assign({}, win, {
-          fullscreen: false,
+          isFullscreen: false,
           icon2x: icon,
           icon: icon.resize({
             width: 16,
@@ -86,7 +86,7 @@ function isFullscreenSelected(dimensions) {
   if (!dimensions.app) {
     return false;
   }
-  return dimensions.app.fullscreen;
+  return dimensions.app.isFullscreen;
 }
 
 function buildMenuItems(options, currentDimensions, windowList) {

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -19,8 +19,7 @@ block body
   section.controls-content
     .controls-section.container
       .controls-section__row
-        .c-select.custom-select
-          Hello
+        .c-select.custom-select Select...
         +select-custom.has-icon.c-select--large.aspect-ratio-select
           +icon('ic_crop_free_24px').o-icon--small
           select.aspect-ratio-selector(tabindex="1")

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -19,7 +19,9 @@ block body
   section.controls-content
     .controls-section.container
       .controls-section__row
-        .c-select.custom-select Select...
+        .c-select.custom-select
+          +icon('ic_crop_free_24px').o-icon--small
+          span.selector-content(data-default-text='Select...') Select...
         +select-custom.has-icon.c-select--large.aspect-ratio-select
           +icon('ic_crop_free_24px').o-icon--small
           select.aspect-ratio-selector(tabindex="1")
@@ -30,10 +32,6 @@ block body
             option(value='3:2') 3:2
             option(value='1:1' selected) 1:1
             option(id="custom-ratio-option" data-aspect-ratio='custom') Custom
-        +select-custom.has-icon.c-select--large.app-select
-          +icon('ic_crop_free_24px').o-icon--small
-          select.app-selector(tabindex="1")
-            option(disabled=true selected=true) Loading…
       .controls-section__row.aspect-ratio
         .aspect-ratio__input
           input#aspect-ratio-width.c-input--large(type='number' value='512' tabindex="1")

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -19,19 +19,9 @@ block body
   section.controls-content
     .controls-section.container
       .controls-section__row
-        .c-select.custom-select
+        +select-custom.has-icon.c-select--large.custom-select
           +icon('ic_crop_free_24px').o-icon--small
-          span.selector-content(data-default-text='Select...') Select...
-        +select-custom.has-icon.c-select--large.aspect-ratio-select
-          +icon('ic_crop_free_24px').o-icon--small
-          select.aspect-ratio-selector(tabindex="1")
-            option(value='16:9') 16:9
-            option(value='5:4') 5:4
-            option(value='5:3') 5:3
-            option(value='4:3') 4:3
-            option(value='3:2') 3:2
-            option(value='1:1' selected) 1:1
-            option(id="custom-ratio-option" data-aspect-ratio='custom') Custom
+          button(data-default-text='Select...' tabindex="1") Select...
       .controls-section__row.aspect-ratio
         .aspect-ratio__input
           input#aspect-ratio-width.c-input--large(type='number' value='512' tabindex="1")

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -19,6 +19,8 @@ block body
   section.controls-content
     .controls-section.container
       .controls-section__row
+        .c-select.custom-select
+          Hello
         +select-custom.has-icon.c-select--large.aspect-ratio-select
           +icon('ic_crop_free_24px').o-icon--small
           select.aspect-ratio-selector(tabindex="1")

--- a/app/src/renderer/views/main.pug
+++ b/app/src/renderer/views/main.pug
@@ -19,9 +19,9 @@ block body
   section.controls-content
     .controls-section.container
       .controls-section__row
-        +select-custom.has-icon.c-select--large.custom-select
+        +select-custom.has-icon.c-select--large.ratio-selector
           +icon('ic_crop_free_24px').o-icon--small
-          button(data-default-text='Select...' tabindex="1") Select...
+          button(tabindex="1") Select...
       .controls-section__row.aspect-ratio
         .aspect-ratio__input
           input#aspect-ratio-width.c-input--large(type='number' value='512' tabindex="1")

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1300,6 +1300,10 @@ lsmod@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
 
+mac-windows@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/mac-windows/-/mac-windows-0.5.4.tgz#7ee2c5c9e83cf8c79c835b18a6e7008bdff52507"
+
 macos-version@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/macos-version/-/macos-version-4.0.1.tgz#ede40927e40ee0610cdb0f40bd94392d052e4fe5"
@@ -1426,6 +1430,10 @@ node-gyp@~3.6.0:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
+
+node-mac-app-icon@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/node-mac-app-icon/-/node-mac-app-icon-1.0.1.tgz#65d5d3edcaf58f8386018c97dac703e895b2a0b3"
 
 "nopt@2 || 3":
   version "3.0.6"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1431,9 +1431,11 @@ node-gyp@~3.6.0:
     tar "^2.0.0"
     which "1"
 
-node-mac-app-icon@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/node-mac-app-icon/-/node-mac-app-icon-1.0.1.tgz#65d5d3edcaf58f8386018c97dac703e895b2a0b3"
+node-mac-app-icon@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-mac-app-icon/-/node-mac-app-icon-1.1.0.tgz#521019090175cc7f9d911f9eb2240252f0142d3a"
+  dependencies:
+    execa "^0.8.0"
 
 "nopt@2 || 3":
   version "3.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,16 +1498,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2094,13 +2087,9 @@ extract-zip@^1.0.3:
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
Still to do:

+ [x] Custom Ratio should update when crop area is resized manually
+ [x] Sometimes Custom Ratio shows weird numbers
+ [x] Apps list should update when they come into view (or Kap window is shown again)
+ [x] When you select an app in the ratio dropdown, I think it should show the app name and icon in the unopened dropdown view instead of Custom (720:239). Same when Fullscreen is selected.
+ [x] Select "16:9" ratio, then write 100 in the first input. Then press the switch button, to switch the ratio. Now it says Custom (14:25), while it should have said Custom (9:16). This is working correctly in Kap Beta.
+ [x] The ratio dropdown should always open in the same place, like previously, and not where the mouse is.

![image](https://user-images.githubusercontent.com/768052/34624484-238f6210-f25e-11e7-95a5-91d724cf2292.png)

![image](https://user-images.githubusercontent.com/768052/34624489-287c32e4-f25e-11e7-9ef3-96ab8d084299.png)

![image](https://user-images.githubusercontent.com/768052/34641964-7e965d7e-f314-11e7-9eca-8c33460074a2.png)
