### PR TITLE
Disable detaching main window

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -27,6 +27,7 @@ const menubar = require('menubar')({
   preloadWindow: true,
   transparent: true,
   resizable: false,
+  movable: false, // Disable detaching the main window
   minWidth: 320
 });
 


### PR DESCRIPTION
This PR temporarily disables the main window movement, in result, the detached mode will become unavailable.   