### PR TITLE
Safely fail if there is no app icon

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.14.1",
     "move-file": "^0.2.0",
     "ms": "^2.0.0",
-    "node-mac-app-icon": "^1.2.2",
+    "node-mac-app-icon": "^1.4.0",
     "npm": "^4.6.1",
     "object-path": "^0.11.3",
     "raven": "^2.3.0",

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -14,8 +14,7 @@ const RATIOS = [
 ];
 
 async function getWindowList() {
-  let windows = await getWindows();
-  windows = [...windows, {pid: 222, ownerName: 'Test'}];
+  const windows = await getWindows();
   const images = await getAppIconListByPid(windows.map(win => win.pid), {
     size: 16,
     encoding: 'buffer',

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -1,6 +1,6 @@
 import {remote, ipcRenderer} from 'electron';
 import {getWindows} from 'mac-windows';
-import {getAppIconByPid} from 'node-mac-app-icon';
+import {getAppIconListByPid} from 'node-mac-app-icon';
 
 const {Menu, nativeImage} = remote;
 
@@ -13,27 +13,13 @@ const RATIOS = [
   '1:1'
 ];
 
-function getAppIconListByPid(pidArray) {
-  const opts = {
-    size: 16,
-    encoding: 'buffer'
-  };
-  // If one of the promises fails, we set the icon to null
-  return Promise.all(
-    pidArray.map(pid => getAppIconByPid(pid, opts).catch(() => null))
-  ).then(
-    result => result.map((icon, i) => ({
-      pid: pidArray[i],
-      icon: icon || null
-    }))
-  );
-}
-
 async function getWindowList() {
-  const windows = await getWindows();
+  let windows = await getWindows();
+  windows = [...windows, {pid: 222, ownerName: 'Test'}];
   const images = await getAppIconListByPid(windows.map(win => win.pid), {
     size: 16,
-    encoding: 'buffer'
+    encoding: 'buffer',
+    failOnError: false
   });
   const {width, height} = remote.screen.getPrimaryDisplay().bounds;
 

--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -13,7 +13,7 @@ const RATIOS = [
   '1:1'
 ];
 
-async function getAppIconListByPid(pidArray) {
+function getAppIconListByPid(pidArray) {
   const opts = {
     size: 16,
     encoding: 'buffer'

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1437,9 +1437,9 @@ node-gyp@~3.6.0:
     tar "^2.0.0"
     which "1"
 
-node-mac-app-icon@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/node-mac-app-icon/-/node-mac-app-icon-1.2.2.tgz#2331944a3a35fde345b282dc2ab05473caee867f"
+node-mac-app-icon@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-mac-app-icon/-/node-mac-app-icon-1.4.0.tgz#2b6d4360f665f626439ecc16b5df6ec160bf1a25"
   dependencies:
     electron-util "^0.4.1"
     execa "^0.8.0"


### PR DESCRIPTION
If there is no app icon (and the command fails), just don't show any icon in app list.