### PR TITLE
Handle non-errors

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "electron-store": "^1.2.0",
     "electron-unhandled": "^0.2.0",
     "electron-util": "^0.2.1",
+    "ensure-error": "^1.0.0",
     "execa": "^0.8.0",
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",

--- a/app/src/main/share-service.js
+++ b/app/src/main/share-service.js
@@ -2,6 +2,7 @@ import electron from 'electron';
 import Store from 'electron-store';
 import Ajv from 'ajv';
 import delay from 'delay';
+import ensureError from 'ensure-error';
 import ShareServiceContext from './share-service-context';
 
 const REQUIRED_KEYS = new Set([
@@ -72,7 +73,7 @@ export default class ShareService {
   }
 
   showError(err) {
-    electron.dialog.showErrorBox(`Error in plugin ${this.pluginName}`, err.stack);
+    electron.dialog.showErrorBox(`Error in plugin ${this.pluginName}`, ensureError(err).stack);
   }
 
   async run(exportOptions) { // `exportOptions` => format filePath width height fps loop

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -627,6 +627,10 @@ ensure-error@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ensure-error/-/ensure-error-0.1.0.tgz#cf3fd3365bf7fd83244731cbd4f30006d99df259"
 
+ensure-error@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ensure-error/-/ensure-error-1.0.0.tgz#c54c13329132cad06f847423b52c22fd88099d0d"
+
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"


### PR DESCRIPTION
Something throws a non-error and `.stack` doesn't exist.

Should at least show us what's wrong in #326.