### PR TITLE
Force CircleCI to build on Git tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,3 +11,11 @@ jobs:
       - run: mv dist/*.dmg dist/Kap.dmg
       - store_artifacts:
           path: dist/Kap.dmg
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/ # Force CircleCI to build on tags


### PR DESCRIPTION
This is needed so that we can push a new tag and have `electron-builder` build and upload artifacts.

See: https://circleci.com/docs/2.0/workflows/#git-tag-job-execution