### PR TITLE
Add default export buttons

### DIFF
--- a/app/src/renderer/css/components/_buttons.css
+++ b/app/src/renderer/css/components/_buttons.css
@@ -167,6 +167,17 @@ button {
   }
 }
 
+.button--dark {
+  border-color: transparent;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  transition: background 0.12s ease-in-out;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+}
+
 /* Large Button */
 .button--large {
   height: 3.2rem;

--- a/app/src/renderer/css/components/_buttons.css
+++ b/app/src/renderer/css/components/_buttons.css
@@ -178,6 +178,12 @@ button {
   }
 }
 
+/* Button with small padding */
+.button--small-padding {
+  padding-right: 0.8rem;
+  padding-left: 0.8rem;
+}
+
 /* Large Button */
 .button--large {
   height: 3.2rem;

--- a/app/src/renderer/css/components/_inputs.css
+++ b/app/src/renderer/css/components/_inputs.css
@@ -155,6 +155,11 @@ input {
       }
     }
   }
+
+  &.is-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }
 
 

--- a/app/src/renderer/css/components/_inputs.css
+++ b/app/src/renderer/css/components/_inputs.css
@@ -99,6 +99,12 @@ input {
     padding-left: 8px;
     font-size: 1.2rem;
 
+    .c-select__label {
+      display: flex;
+      height: 100%;
+      align-items: center;
+    }
+
     select {
       width: 100%;
       height: 100%;

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -218,8 +218,9 @@ section.output {
   margin-left: auto;
   align-items: center;
 
-  & > button:not(:last-child) {
-    margin-right: 5px;
+  & > button:not(:first-child),
+  & > .c-select:not(:first-child) {
+    margin-right: 8px;
   }
 }
 

--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -248,8 +248,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function registerExportOptions() {
+    // Use select elements to get intial list of export formats, even if we won't use the select down the line
     const exportFormats = document.querySelectorAll('.output-format .c-select');
-    console.log(exportFormats);
 
     ipcRenderer.on('toggle-format-buttons', (event, data) => {
       for (const btn of exportFormats) {
@@ -260,6 +260,7 @@ document.addEventListener('DOMContentLoaded', () => {
     for (const formatElement of exportFormats) {
       const format = formatElement.dataset.exportType;
       const dropdown = formatElement.querySelector('select');
+      const formatButton = document.querySelector(`.output-format button[data-export-type='${format}']`);
 
       let i = 0;
       for (const service of shareServices) {
@@ -275,16 +276,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
       formatElement.appendChild(dropdown);
 
-      // Prevent the dropdown from triggering the button
-      dropdown.onclick = event => {
-        event.stopPropagation();
-      };
+      // If there are more than the label and default export format, show the select
+      // Else show a button instead of a dropdown that handles only "save to file"
+      if (dropdown.children.length > 2) {
+        // Prevent the dropdown from triggering the button
+        dropdown.onclick = event => {
+          event.stopPropagation();
+        };
 
-      dropdown.onchange = () => { // eslint-disable-line no-loop-func
-        const service = shareServices[dropdown.value];
-        handleFile(service, format);
-        dropdown.value = '-1';
-      };
+        dropdown.onchange = () => { // eslint-disable-line no-loop-func
+          const service = shareServices[dropdown.value];
+          handleFile(service, format);
+          dropdown.value = '-1';
+        };
+      } else {
+        const service = shareServices[0];
+        formatElement.classList.add('hidden');
+        formatButton.classList.remove('hidden');
+
+        formatButton.onclick = () => handleFile(service, format);
+      }
     }
   }
 

--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -253,7 +253,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     ipcRenderer.on('toggle-format-buttons', (event, data) => {
       for (const btn of exportFormats) {
-        btn.disabled = !data.enabled;
+        const formatButton = document.querySelector(`.output-format button[data-export-type='${btn.dataset.exportType}']`);
+        formatButton.disabled = !data.enabled;
+        btn.classList.toggle('is-disabled', !data.enabled);
       }
     });
 

--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function registerExportOptions() {
-    // Use select elements to get intial list of export formats, even if we won't use the select down the line
+    // Use select elements to get initial list of export formats, even if we won't use the select down the line
     const exportFormats = document.querySelectorAll('.output-format .c-select');
 
     ipcRenderer.on('toggle-format-buttons', (event, data) => {

--- a/app/src/renderer/views/editor.pug
+++ b/app/src/renderer/views/editor.pug
@@ -48,22 +48,22 @@ block body
             span 30
     .output-format
       span Export
-      button.button.button--dark.hidden(data-export-type="gif") GIF
+      button.button.button--dark.button--small-padding.hidden(data-export-type="gif") GIF
       +select-custom(data-export-type="gif").is-transparent.has-custom-label
         .c-select__label GIF
         select
           option(selected disabled value="-1") Export destinations
-      button.button.button--dark.hidden(data-export-type="mp4") MP4
+      button.button.button--dark.button--small-padding.hidden(data-export-type="mp4") MP4
       +select-custom(data-export-type="mp4").is-transparent.has-custom-label
         .c-select__label MP4
         select
           option(selected disabled value="-1") Export destinations
-      button.button.button--dark.hidden(data-export-type="webm") WebM
+      button.button.button--dark.button--small-padding.hidden(data-export-type="webm") WebM
       +select-custom(data-export-type="webm").is-transparent.has-custom-label
         .c-select__label WebM
         select
           option(selected disabled value="-1") Export destinations
-      button.button.button--dark.hidden(data-export-type="apng") APNG
+      button.button.button--dark.button--small-padding.hidden(data-export-type="apng") APNG
       +select-custom(data-export-type="apng").is-transparent.has-custom-label
         .c-select__label APNG
         select

--- a/app/src/renderer/views/editor.pug
+++ b/app/src/renderer/views/editor.pug
@@ -48,19 +48,23 @@ block body
             span 30
     .output-format
       span Export
+      button.button.button--dark.hidden(data-export-type="gif") GIF
       +select-custom(data-export-type="gif").is-transparent.has-custom-label
         .c-select__label GIF
         select
           option(selected disabled value="-1") Export destinations
-      +select-custom(data-export-type="mp4").is-transparent.has-custom-label.u-margin-left--small
+      button.button.button--dark.hidden(data-export-type="mp4") MP4
+      +select-custom(data-export-type="mp4").is-transparent.has-custom-label
         .c-select__label MP4
         select
           option(selected disabled value="-1") Export destinations
-      +select-custom(data-export-type="webm").is-transparent.has-custom-label.u-margin-left--small
+      button.button.button--dark.hidden(data-export-type="webm") WebM
+      +select-custom(data-export-type="webm").is-transparent.has-custom-label
         .c-select__label WebM
         select
           option(selected disabled value="-1") Export destinations
-      +select-custom(data-export-type="apng").is-transparent.has-custom-label.u-margin-left--small
+      button.button.button--dark.hidden(data-export-type="apng") APNG
+      +select-custom(data-export-type="apng").is-transparent.has-custom-label
         .c-select__label APNG
         select
           option(selected disabled value="-1") Export Options


### PR DESCRIPTION
This PR proposes and implements buttons for share services which would only show if there is only the `Save to file` option for the particular format the button is for. 

In theory, this decreases the effort for users to get to their desired output when there is no need for a select element with just one option.

![image](https://user-images.githubusercontent.com/1695613/35252193-2794e372-ffd7-11e7-8136-0ce91d937dc9.png)

In the image above, I have `kap-imgur` installed and so the GIF option is a select element due to multiple options for that format.