### PR TITLE
Remove `cursor:pointer`

### DIFF
--- a/app/src/renderer/css/_helpers.css
+++ b/app/src/renderer/css/_helpers.css
@@ -8,7 +8,6 @@
 
 /* Allow element to be held down to drag the current window */
 .webkit-drag {
-  cursor: -webkit-grab;
   -webkit-app-region: drag;
 }
 

--- a/app/src/renderer/css/components/_buttons.css
+++ b/app/src/renderer/css/components/_buttons.css
@@ -7,11 +7,6 @@
   - Any extensions to input styling should go in this file
 */
 
-/* Ensure all buttons have the pointer cursor */
-.btn {
-  cursor: pointer;
-}
-
 /* Button */
 *[class^='button'] {
   height: 2.4rem;
@@ -22,7 +17,6 @@
   font-size: 1.2rem;
   text-align: center;
   line-height: 2.4rem;
-  cursor: pointer;
 }
 
 

--- a/app/src/renderer/css/components/_range.css
+++ b/app/src/renderer/css/components/_range.css
@@ -27,7 +27,6 @@
     border: 1px solid $blue;
     border-radius: 50%;
     background: $blue;
-    cursor: pointer;
     -webkit-appearance: none;
   }
 

--- a/app/src/renderer/css/components/_slider.css
+++ b/app/src/renderer/css/components/_slider.css
@@ -37,13 +37,5 @@
     transition: all 0.16s ease-in-out;
     pointer-events: auto;
     -webkit-appearance: none;
-
-    &:hover {
-      cursor: -webkit-grab;
-    }
-
-    &:active {
-      cursor: -webkit-grabbing;
-    }
   }
 }

--- a/app/src/renderer/css/components/_slider.css
+++ b/app/src/renderer/css/components/_slider.css
@@ -26,7 +26,6 @@
     border-color: transparent;
     color: transparent;
     background: transparent;
-    cursor: pointer;
   }
 
   &::-webkit-slider-thumb {

--- a/app/src/renderer/css/components/_toggle.css
+++ b/app/src/renderer/css/components/_toggle.css
@@ -38,7 +38,6 @@
     position: relative;
     background-color: #fff;
     transition: 0.2s ease-in-out;
-    cursor: pointer;
 
     &::after {
       content: '';

--- a/app/src/renderer/css/components/_window-header.css
+++ b/app/src/renderer/css/components/_window-header.css
@@ -41,7 +41,6 @@
     color: $color-primary;
     font-size: $font-size-default;
     line-height: 3.6rem;
-    cursor: -webkit-drag;
   }
   /* Toolbar: */
   &.is-large::before {
@@ -85,7 +84,6 @@
   }
 
   &.is-draggable {
-    cursor: -webkit-grab;
     -webkit-app-region: drag;
   }
 }

--- a/app/src/renderer/css/cropper.css
+++ b/app/src/renderer/css/cropper.css
@@ -15,16 +15,7 @@ svg {
 }
 
 .window-dragger {
-  cursor: -webkit-grab;
   -webkit-app-region: drag;
-
-  &:active {
-    cursor: -webkit-grabbing;
-    /*
-     * TODO: this doesn't work because of `-webkit-app-region`; implement a workaround
-     * with IPC
-     */
-  }
 }
 
 rect.stroke-black {

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -179,10 +179,6 @@ video {
   transition: 200ms ease-out transform;
 }
 
-.timeline-container {
-  cursor: pointer;
-}
-
 .timeline-container:hover .timeline-markers .slider::-webkit-slider-thumb {
   width: 4px;
   height: 16px;
@@ -258,7 +254,6 @@ ul {
   background: #414141;
   box-shadow: inset 0 1px rgba(255, 255, 255, 0.05), 0 1px 2px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.1);
   text-align: center;
-  cursor: pointer;
 }
 
 @keyframes shake {

--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -78,7 +78,6 @@ body.is-tray-arrow-hidden {
     height: 2.4rem;
     color: $color-primary;
     font-size: 1.2rem;
-    /* cursor: -webkit-grab; */
 
     &:hover {
       color: $color-primary;

--- a/app/src/renderer/css/main.css
+++ b/app/src/renderer/css/main.css
@@ -143,7 +143,6 @@ body.is-tray-arrow-hidden {
     border: 2px solid #fff;
     border-radius: 50%;
     transition: border-radius 0.12s ease-in-out, background 0.12s ease-in-out;
-    cursor: pointer;
   }
 
   &.is-cropping .record__state {
@@ -188,12 +187,10 @@ body.is-tray-arrow-hidden {
     color: #fff;
     background: #2d2d2d;
     font-size: 1.4rem;
-    cursor: pointer;
 
     /* Text inside the toggle */
     &__title {
       margin-left: 1rem;
-      cursor: pointer !important;
     }
 
     /* Directional transform of arrow in toggle */

--- a/app/src/renderer/css/preferences.css
+++ b/app/src/renderer/css/preferences.css
@@ -100,6 +100,10 @@ nav.prefs-nav {
   &:last-of-type {
     border-bottom: 1px solid $gray-lighter;
   }
+
+  &:hover {
+    cursor: default; /* Prevent text selection cursor */
+  }
 }
 
 .preference-part {

--- a/app/src/renderer/css/preferences.css
+++ b/app/src/renderer/css/preferences.css
@@ -38,6 +38,7 @@ nav.prefs-nav {
     margin-right: 16px;
     color: $gray-darker;
     transition: color 0.12s ease-in-out;
+    cursor: default;
 
     svg {
       transition: fill 0.12s ease-in-out;


### PR DESCRIPTION
Native apps do not use the pointer cursor except for links. We should make sure Kap feels as native as possible.

I would also like to remove the grabbing hands from the editor trimmer, but I didn't include that here as I guessed it would be more controversial. Thoughts? Quicktime, for example, does not have a grabbing cursor on the trimming UI.