### PR TITLE
Don't close Preferences window when it loses focus

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -292,15 +292,6 @@ function openPrefsWindow() {
 
   prefsWindow.loadURL(`file://${__dirname}/../renderer/views/preferences.html`);
   prefsWindow.on('ready-to-show', prefsWindow.show);
-
-  prefsWindow.on('blur', () => {
-    // Because of issues on our codebase and on the `menubar` module,
-    // for now we'll have this ugly workaround: if the main window is attached
-    // to the menubar, we'll just close the prefs window when it loses focus
-    if (!mainWindowIsDetached && !prefsWindow.webContents.isDevToolsFocused()) {
-      prefsWindow.close();
-    }
-  });
 }
 
 function getCropperWindow() {


### PR DESCRIPTION
No idea why it was done in the first place, but the behavior is really annoying.