### PR TITLE
Handle plugin request cancelation

### DIFF
--- a/app/src/main/convert.js
+++ b/app/src/main/convert.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import {ipcMain} from 'electron';
 import tempy from 'tempy';
-import {CancelError} from 'p-cancelable';
 import {convertToGif, convertToMp4, convertToWebm, convertToApng} from '../scripts/convert';
 import {exportProgress} from './export';
 
@@ -43,14 +42,7 @@ export default async function (exportOptions) {
     convertProcess.cancel();
   });
 
-  try {
-    await convertProcess;
-  } catch (err) {
-    if (err instanceof CancelError) {
-      return;
-    }
-    throw err;
-  }
+  await convertProcess;
 
   return outputPath;
 }

--- a/app/src/main/share-service-context.js
+++ b/app/src/main/share-service-context.js
@@ -18,13 +18,13 @@ export default class ShareServiceContext {
 
   // TODO: Implement progress reporting
   async request(url, options) {
-    const request = got(url, Object.assign({}, options, {useElectronNet: false}));
+    const req = got(url, Object.assign({}, options, {useElectronNet: false}));
 
     ipcMain.on('cancel-export', () => {
-      request.cancel();
+      req.cancel();
     });
 
-    return await request;
+    return req;
   }
 
   cancel() {

--- a/app/src/main/share-service-context.js
+++ b/app/src/main/share-service-context.js
@@ -1,4 +1,4 @@
-import electron from 'electron';
+import electron, {ipcMain} from 'electron';
 import got from 'got';
 import moment from 'moment';
 import convert from './convert';
@@ -18,7 +18,13 @@ export default class ShareServiceContext {
 
   // TODO: Implement progress reporting
   async request(url, options) {
-    return got(url, Object.assign({}, options, {useElectronNet: false}));
+    const request = got(url, Object.assign({}, options, {useElectronNet: false}));
+
+    ipcMain.on('cancel-export', () => {
+      request.cancel();
+    });
+
+    return await request;
   }
 
   cancel() {

--- a/app/src/main/share-service.js
+++ b/app/src/main/share-service.js
@@ -3,6 +3,7 @@ import Store from 'electron-store';
 import Ajv from 'ajv';
 import delay from 'delay';
 import ensureError from 'ensure-error';
+import {CancelError} from 'p-cancelable';
 import ShareServiceContext from './share-service-context';
 import {endExport, startExport, hideExportWindow} from './export';
 
@@ -116,7 +117,11 @@ export default class ShareService {
       }
     } catch (err) {
       hideExportWindow();
-      this.showError(err);
+      if (err instanceof CancelError) {
+        kap.editorWindow.focus();
+      } else {
+        this.showError(err);
+      }
     }
 
     kap.editorWindow.send('toggle-format-buttons', {enabled: true});


### PR DESCRIPTION
Fixes #357

Convert process should now throw an error instead of silently failing, because the plugins are also using that, so if it silently fails, they should handle the cancellation because they are calling `context.filePath()`. But if it throws an error, we can catch and check it's type.