### PR TITLE
Allow only one plugin to be installing/uninstalling at the time

### DIFF
--- a/app/src/renderer/js/preferences.js
+++ b/app/src/renderer/js/preferences.js
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const el = e.target;
     const name = el.dataset.name;
 
-    el.disabled = true;
+    $j('.plugins-list .install-toggle').prop('disabled', true);
 
     if (el.checked) {
       el.classList.add('loading');


### PR DESCRIPTION
If you tried toggling multiple plugins at once, it would throw an error.

**DON'T MERGE**