### PR TITLE
Disable windows sub menu if there are no selectable windows

### DIFF
--- a/app/src/renderer/js/size-selector.js
+++ b/app/src/renderer/js/size-selector.js
@@ -160,7 +160,8 @@ function buildMenuItems(options, currentDimensions, windowList) {
   return Menu.buildFromTemplate([
     {
       label: 'Windows',
-      submenu: getSortedAppList(appList).map(win => ({
+      enabled: appList.length > 0,
+      submenu: appList.length > 0 ? getSortedAppList(appList).map(win => ({
         label: win.ownerName,
         icon: win.icon,
         type: 'radio',
@@ -169,7 +170,7 @@ function buildMenuItems(options, currentDimensions, windowList) {
           setAppLastUsed(win);
           emitter.emit('app-selected', win);
         }
-      }))
+      })) : null
     },
     {
       label: 'Fullscreen',


### PR DESCRIPTION
Fix #363

If I send the empty submenu array, the menu isn't greyed out 🙁 

![image](https://user-images.githubusercontent.com/5027156/35682187-10659e72-0760-11e8-8fe8-e425339db64f.png)
