### PR TITLE
Fix `NonError: 1` and make MP4 obey `fps` and `dimensions`

### DIFF
--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -71,10 +71,11 @@ const convertToGif = PCancelable.fn(async (onCancel, opts) => {
 });
 
 function convertToMp4(opts) {
-  // TODO: Instead of fixing the `file://` prefix here, just store it in a better place in the editor
   opts.progressCallback(0);
   return convert(opts.outputPath, opts, [
     '-i', opts.filePath,
+    '-r', opts.fps,
+    '-s', `${opts.width}x${opts.height}`,
     '-ss', opts.startTime,
     '-to', opts.endTime,
     opts.outputPath
@@ -92,6 +93,8 @@ function convertToWebm(opts) {
     '-codec:v', 'vp9',
     '-codec:a', 'vorbis',
     '-strict', '-2', // Needed because `vorbis` is experimental
+    '-r', opts.fps,
+    '-s', `${opts.width}x${opts.height}`,
     '-ss', opts.startTime,
     '-to', opts.endTime,
     opts.outputPath

--- a/app/src/scripts/convert.js
+++ b/app/src/scripts/convert.js
@@ -70,12 +70,15 @@ const convertToGif = PCancelable.fn(async (onCancel, opts) => {
   ]);
 });
 
+// https://trac.ffmpeg.org/ticket/309
+const makeEven = n => 2 * Math.round(n / 2);
+
 function convertToMp4(opts) {
   opts.progressCallback(0);
   return convert(opts.outputPath, opts, [
     '-i', opts.filePath,
     '-r', opts.fps,
-    '-s', `${opts.width}x${opts.height}`,
+    '-s', `${makeEven(opts.width)}x${makeEven(opts.height)}`,
     '-ss', opts.startTime,
     '-to', opts.endTime,
     opts.outputPath


### PR DESCRIPTION
Fixes #377
Fixes #400

The `NonError: 1` was caused by ffmpeg when trying to convert to mp4, when width or height were odd. Apparently, because of libx264, height and width have to be even (https://trac.ffmpeg.org/ticket/309). So getting the error was pretty random. Also, it was even worse, since when exporting mp4 wouldn't listen to the chosen dimensions as described in the other issue. So it was basically chances of your original recording having even dimensions. 

This PR passes the size and fps options to the mp4 converter and also makes sure the width and height are even to avoid getting that error.

Some Acceptance Testing would be nice! (I tested it a bunch already, but second pair of eyes doesn't hurt)

Also, the dimension being ignored problem was there for WebM format too, so I added the options for that converter as well