### PR TITLE
Blacklist menubar icons from the window selector

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -34,7 +34,7 @@
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",
-    "mac-windows": "^0.5.4",
+    "mac-windows": "^0.6.0",
     "make-dir": "^1.2.0",
     "menubar": "github:matheuss/menubar",
     "moment": "^2.20.1",


### PR DESCRIPTION
Updates the [mac-windows](https://github.com/karaggeorge/mac-windows) dependency, to improve the logic for detecting menubar icons in the list of windows

Fixes #327