### PR TITLE
Add user preference to hide desktop icons during recording

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",
     "got": "^8.2.0",
-    "hide-desktop-icons": "^0.1.3",
+    "hide-desktop-icons": "^0.3.0",
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",
     "got": "^8.2.0",
-    "hide-desktop-icons": "^0.1.2",
+    "hide-desktop-icons": "^0.1.3",
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",

--- a/app/package.json
+++ b/app/package.json
@@ -31,6 +31,7 @@
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",
     "got": "^8.2.0",
+    "hide-desktop-icons": "^0.1.2",
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",

--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -11,6 +11,7 @@ const DEFAULTS = {
   allowAnalytics: true,
   showCursor: true,
   highlightClicks: false,
+  hideDesktopIcons: false,
   fps: 30,
   recordAudio: false,
   audioInputDeviceId: null,

--- a/app/src/renderer/css/preferences.css
+++ b/app/src/renderer/css/preferences.css
@@ -113,6 +113,22 @@ nav.prefs-nav {
       padding: 16px;
     }
   }
+
+  &.experimental .preference__title::after {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    color: $gray-darker;
+    content: 'experimental';
+    display: inline-block;
+    font-size: 1rem;
+    /* stylelint-disable font-weight-notation */
+    font-weight: 500;
+    /* stylelint-enable */
+    margin: 0 1rem;
+    padding: 0 0.8rem;
+    text-transform: uppercase;
+    width: max-content;
+  }
 }
 
 .preference-content {

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -2,6 +2,7 @@ import {ipcRenderer, remote} from 'electron';
 import EventEmitter from 'events';
 import {default as createAperture, audioDevices} from 'aperture';
 import _ from 'lodash';
+import desktopIcons from 'hide-desktop-icons';
 
 import {init as initErrorReporter, report as reportError} from '../../common/reporter';
 import {log} from '../../common/logger';
@@ -135,6 +136,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
+    if (app.kap.settings.get('hideDesktopIcons')) await desktopIcons.hide();
+
     try {
       await aperture.startRecording(apertureOpts);
       ipcRenderer.send('did-start-recording');
@@ -157,6 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.send('will-stop-recording');
 
     const filePath = await aperture.stopRecording();
+    if (app.kap.settings.get('hideDesktopIcons')) desktopIcons.show();
     ipcRenderer.send('stopped-recording');
     ipcRenderer.send('open-editor-window', {filePath});
     setMainWindowSize();

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -136,7 +136,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    if (app.kap.settings.get('hideDesktopIcons')) await desktopIcons.hide();
+    if (app.kap.settings.get('hideDesktopIcons')) {
+      await desktopIcons.hide();
+    }
 
     try {
       await aperture.startRecording(apertureOpts);
@@ -160,7 +162,11 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.send('will-stop-recording');
 
     const filePath = await aperture.stopRecording();
-    if (app.kap.settings.get('hideDesktopIcons')) desktopIcons.show();
+
+    if (app.kap.settings.get('hideDesktopIcons')) {
+      desktopIcons.show();
+    }
+
     ipcRenderer.send('stopped-recording');
     ipcRenderer.send('open-editor-window', {filePath});
     setMainWindowSize();

--- a/app/src/renderer/js/preferences.js
+++ b/app/src/renderer/js/preferences.js
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     app.kap.settings.set('highlightClicks', this.checked);
   });
 
-  hideDesktopIconsCheckbox.addEventListener('change', function() {
+  hideDesktopIconsCheckbox.addEventListener('change', function () {
     app.kap.settings.set('hideDesktopIcons', this.checked);
   });
 

--- a/app/src/renderer/js/preferences.js
+++ b/app/src/renderer/js/preferences.js
@@ -28,6 +28,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const openOnStartupCheckbox = $('#open-on-startup');
   const saveToDescription = $('.js-save-to-description');
   const showCursorCheckbox = $('#show-cursor');
+  const hideDesktopIconsCheckbox = $('#hide-desktop-icons');
   const openPluginsFolder = $('.js-open-plugins');
 
   const electronWindow = getCurrentWindow();
@@ -42,6 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   openOnStartupCheckbox.checked = settingsValues.openOnStartup;
   allowAnalyticsCheckbox.checked = settingsValues.allowAnalytics;
   showCursorCheckbox.checked = settingsValues.showCursor;
+  hideDesktopIconsCheckbox.checked = settingsValues.hideDesktopIcons;
   if (settingsValues.showCursor === false) {
     highlightClicksCheckbox.disabled = true;
   } else {
@@ -181,6 +183,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   highlightClicksCheckbox.addEventListener('change', function () {
     app.kap.settings.set('highlightClicks', this.checked);
+  });
+
+  hideDesktopIconsCheckbox.addEventListener('change', function() {
+    app.kap.settings.set('hideDesktopIcons', this.checked);
   });
 
   fpsSlider.addEventListener('input', function () {

--- a/app/src/renderer/views/preferences.pug
+++ b/app/src/renderer/views/preferences.pug
@@ -47,11 +47,11 @@ block body
           +toggle('show-cursor')
         .preference-part
           .preference-content
-            .preference__title Highlight clicks
+            .preference__description Highlight clicks
           +toggle('highlight-clicks')
         .preference-part.experimental
           .preference-content
-            .preference__title Hide Desktop Icons
+            .preference__title Hide desktop icons
             .preference__description Temporarily hide the desktop icons while recording
           +toggle('hide-desktop-icons')
       .preference.container

--- a/app/src/renderer/views/preferences.pug
+++ b/app/src/renderer/views/preferences.pug
@@ -47,8 +47,13 @@ block body
           +toggle('show-cursor')
         .preference-part
           .preference-content
-            .preference__description Highlight clicks
+            .preference__title Highlight clicks
           +toggle('highlight-clicks')
+        .preference-part.experimental
+          .preference-content
+            .preference__title Hide Desktop Icons
+            .preference__description Temporarily hide the desktop icons while recording
+          +toggle('hide-desktop-icons')
       .preference.container
         .preference-part
           .preference-content

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -409,19 +409,9 @@ concat-stream@^1.5.0, concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-conf@^1.3.0:
+conf@^1.3.0, conf@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/conf/-/conf-1.3.1.tgz#829a82b081bb355129992333be1598f797a56f58"
-  dependencies:
-    dot-prop "^4.1.0"
-    env-paths "^1.0.0"
-    make-dir "^1.0.0"
-    pkg-up "^2.0.0"
-    write-file-atomic "^2.3.0"
-
-conf@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/conf/-/conf-1.4.0.tgz#1ea66c9d7a9b601674a5bb9d2b8dc3c726625e67"
   dependencies:
     dot-prop "^4.1.0"
     env-paths "^1.0.0"
@@ -1085,6 +1075,13 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
+hide-desktop-icons@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/hide-desktop-icons/-/hide-desktop-icons-0.3.0.tgz#0c55365f15d5fff25b9fc337c2675b47b9e2d28d"
+  dependencies:
+    execa "^0.9.0"
+    wallpaper "^2.6.0"
+
 hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
@@ -1497,11 +1494,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.3.0:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.17.5:
+lodash@^4.14.0, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -1530,13 +1523,7 @@ macos-version@^4.0.1:
   dependencies:
     semver "^5.3.0"
 
-make-dir@^1.0.0, make-dir@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.1.0.tgz#19b4369fe48c116f53c2af95ad102c0e39e85d51"
-  dependencies:
-    pify "^3.0.0"
-
-make-dir@^1.2.0:
+make-dir@^1.0.0, make-dir@^1.1.0, make-dir@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"
   dependencies:
@@ -1671,11 +1658,11 @@ move-file@^1.0.0:
     make-dir "^1.1.0"
     path-exists "^3.0.0"
 
-ms@2.0.0, ms@^2.0.0:
+ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.1.1:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -2150,7 +2137,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -2906,6 +2893,12 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+wallpaper@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/wallpaper/-/wallpaper-2.6.0.tgz#e04390918cb5ecc6ad41bc9026cb2c66f6682b20"
+  dependencies:
+    pify "^2.3.0"
 
 wcwidth@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,6 @@ acorn@^4.0.4, acorn@~4.0.2:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
-
 acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
@@ -167,7 +163,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.0:
+ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -996,21 +992,13 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
   dependencies:
     ansi-styles "^3.2.0"
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
-
-chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 character-entities-html4@^1.0.0:
   version "1.1.1"
@@ -1689,16 +1677,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -2133,14 +2114,7 @@ eslint@^4.17.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.1.3:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
-  dependencies:
-    acorn "^5.2.1"
-    acorn-jsx "^3.0.0"
-
-espree@^3.5.2:
+espree@^3.1.3, espree@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.3.tgz#931e0af64e7fbbed26b050a29daad1fc64799fa6"
   dependencies:
@@ -2326,13 +2300,9 @@ extract-zip@^1.0.3:
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
@@ -2961,10 +2931,6 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -4213,7 +4179,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.4, micromatch@^3.1.4:
+micromatch@^3.0.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.4.tgz#bb812e741a41f982c854e42b421a7eac458796f4"
   dependencies:
@@ -4231,7 +4197,7 @@ micromatch@^3.0.4, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-micromatch@^3.1.8:
+micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
   dependencies:
@@ -4249,25 +4215,15 @@ micromatch@^3.1.8:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-mime-db@~1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
-
 mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12, mime-types@~2.1.17:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
-
-mime-types@~2.1.7:
-  version "2.1.17"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
-  dependencies:
-    mime-db "~1.30.0"
 
 mime@^2.2.0:
   version "2.2.0"
@@ -5242,7 +5198,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.3, postcss@^6.0.6, postcss@^6.0.8, postcss@^6.0.9:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.8, postcss@^6.0.9:
   version "6.0.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.15.tgz#f460cd6269fede0d1bf6defff0b934a9845d974d"
   dependencies:
@@ -5250,7 +5206,7 @@ postcss@^6.0.0, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.
     source-map "^0.6.1"
     supports-color "^5.1.0"
 
-postcss@^6.0.1, postcss@^6.0.16, postcss@^6.0.17:
+postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.16, postcss@^6.0.17, postcss@^6.0.3, postcss@^6.0.6:
   version "6.0.19"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
   dependencies:
@@ -5289,7 +5245,7 @@ private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
-process-nextick-args@^1.0.6, process-nextick-args@^1.0.7, process-nextick-args@~1.0.6:
+process-nextick-args@^1.0.6, process-nextick-args@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
@@ -5476,16 +5432,7 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
-  dependencies:
-    deep-extend "~0.4.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
-rc@^1.1.2, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7, rc@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
@@ -5559,19 +5506,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.2, readable-stream@^2.1.5:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
   dependencies:
@@ -6424,12 +6359,6 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  dependencies:
-    has-flag "^2.0.0"
-
 supports-color@^5.1.0, supports-color@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
@@ -6599,13 +6528,7 @@ token-stream@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/token-stream/-/token-stream-0.0.1.tgz#ceeefc717a76c4316f126d0b9dbaa55d7e7df01a"
 
-tough-cookie@~2.3.0:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
-  dependencies:
-    punycode "^1.4.1"
-
-tough-cookie@~2.3.3:
+tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
@@ -6842,11 +6765,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 


### PR DESCRIPTION
Fixes #372

Uses [hide-desktop-icons](https://github.com/karaggeorge/hide-desktop-icons) to create a window at the icon level with a picture that is the user's wallpaper, therefore hiding the icons.

Electron's BrowserWindow with the `desktop` type uses:
> The desktop type places the window at the desktop background window level (kCGDesktopWindowLevel - 1). Note that desktop window will not receive focus, keyboard or mouse events, but you can use globalShortcut to receive input sparingly.

But, we need `kCGDesktopIconWindowLevel`. Using the `desktop` option produces something like this (behind the icons):
<img width="564" alt="screen shot 2018-02-27 at 15 31 32" src="https://user-images.githubusercontent.com/8822835/36805316-106eef82-1c8b-11e8-91a1-67154ae21e29.png">

I submitted a PR with Electron, to ask for a different type as a new feature, but until then I wrote a swift script to do it

Gifs
---
Excuse my mess of a desktop (reason why I need this 😆)

### Resulting Gifs
Without the option:

![kapture 2018-02-28 at 13 10 36](https://user-images.githubusercontent.com/8822835/36804940-0d1fb920-1c8a-11e8-85d0-045f029df1cb.gif)

With the option:
![kapture 2018-02-28 at 13 14 56](https://user-images.githubusercontent.com/8822835/36804945-11fc0962-1c8a-11e8-9292-ea085f046ac5.gif)

### User experience
[Gif](https://www.dropbox.com/s/iqayfrwj3rgznsq/Kapture%202018-02-28%20at%2013.12.23.gif?dl=0) showing what actually happens when you record it (too large to upload)

### New Preferences Option (defaults to false)
![screen shot 2018-02-28 at 13 34 38](https://user-images.githubusercontent.com/8822835/36805731-2d1c7234-1c8c-11e8-9889-d90d7fde3c89.png)
