### PR TITLE
Update hide-desktop-icons dependency to make it work with ASAR

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,7 @@
     "file-size": "^1.0.0",
     "first-run": "^1.2.0",
     "got": "^8.2.0",
-    "hide-desktop-icons": "^0.3.0",
+    "hide-desktop-icons": "^0.4.0",
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",

--- a/app/package.json
+++ b/app/package.json
@@ -35,7 +35,7 @@
     "insight": "^0.10.0",
     "jquery": "^3.3.1",
     "lodash": "^4.17.5",
-    "mac-windows": "^0.6.0",
+    "mac-windows": "^0.7.1",
     "make-dir": "^1.2.0",
     "menubar": "github:matheuss/menubar",
     "moment": "^2.20.1",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -59,6 +59,13 @@ agentkeepalive@^3.3.0:
   dependencies:
     humanize-ms "^1.2.1"
 
+aggregate-error@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-1.0.0.tgz#888344dad0220a72e3af50906117f48771925fac"
+  dependencies:
+    clean-stack "^1.0.0"
+    indent-string "^3.0.0"
+
 ajv@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
@@ -131,6 +138,10 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arrify@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asap@^2.0.0:
   version "2.0.6"
@@ -310,7 +321,7 @@ cidr-regex@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cidr-regex/-/cidr-regex-1.0.6.tgz#74abfd619df370b9d54ab14475568e97dd64c0c1"
 
-clean-stack@^1.3.0:
+clean-stack@^1.0.0, clean-stack@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-1.3.0.tgz#9e821501ae979986c46b1d66d2d432db2fd4ae31"
 
@@ -489,6 +500,13 @@ create-error-class@^3.0.0:
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
     capture-stack-trace "^1.0.0"
+
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -699,6 +717,12 @@ electron-util@^0.6.0:
   dependencies:
     electron-is-dev "^0.3.0"
 
+electron-util@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/electron-util/-/electron-util-0.7.0.tgz#6cc94ae4f4280725ac10e05b54ecfae6033be045"
+  dependencies:
+    electron-is-dev "^0.3.0"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -748,6 +772,14 @@ es6-promisify@^5.0.0:
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+execa@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.1.1.tgz#b09c2a9309bc0ef0501479472db3180f8d4c3edd"
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    object-assign "^4.0.1"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -854,6 +886,15 @@ first-run@^1.2.0:
   dependencies:
     configstore "^2.0.0"
     read-pkg-up "^1.0.1"
+
+fkill@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/fkill/-/fkill-5.2.0.tgz#68abea133b950963170dcf5af3ae2da78b71794e"
+  dependencies:
+    aggregate-error "^1.0.0"
+    arrify "^1.0.0"
+    execa "^0.8.0"
+    taskkill "^2.0.0"
 
 flush-write-stream@^1.0.0:
   version "1.0.2"
@@ -1075,11 +1116,13 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-hide-desktop-icons@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/hide-desktop-icons/-/hide-desktop-icons-0.3.0.tgz#0c55365f15d5fff25b9fc337c2675b47b9e2d28d"
+hide-desktop-icons@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/hide-desktop-icons/-/hide-desktop-icons-0.4.0.tgz#2081f1260c505ee84155674992d3a75843b7c39f"
   dependencies:
+    electron-util "^0.7.0"
     execa "^0.9.0"
+    fkill "^5.2.0"
     wallpaper "^2.6.0"
 
 hoek@4.x.x:
@@ -1143,6 +1186,10 @@ import-lazy@^2.1.0:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4, inflight@~1.0.6:
   version "1.0.6"
@@ -1502,7 +1549,7 @@ lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@~4.1.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
@@ -2721,6 +2768,13 @@ tar@^4.0.2, tar@^4.2.0:
     mkdirp "^0.5.0"
     yallist "^3.0.2"
 
+taskkill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/taskkill/-/taskkill-2.0.0.tgz#a354305702a964357033027aa949eaed5331b784"
+  dependencies:
+    arrify "^1.0.0"
+    execa "^0.1.1"
+
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -2910,7 +2964,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@~1.3.0:
+which@1, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.0, which@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1556,9 +1556,9 @@ lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@~4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-mac-windows@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/mac-windows/-/mac-windows-0.6.0.tgz#7c867712865c1f12cb9ecf50fe2cab067fc37008"
+mac-windows@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/mac-windows/-/mac-windows-0.7.1.tgz#3309ef0c7c508725cc3e17a3ea1687de0680c78b"
 
 macos-release@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
As per https://github.com/karaggeorge/hide-desktop-icons/issues/4

Fixed in: https://github.com/karaggeorge/hide-desktop-icons/commit/71c477e855406dc5310d1f18305054bb35b503c3