### PR TITLE
Include the application name in update notification

### DIFF
--- a/app/src/main/auto-updater.js
+++ b/app/src/main/auto-updater.js
@@ -38,7 +38,7 @@ export const init = () => {
     log('Update downloaded, will notify the user');
 
     const notification = new Notification({
-      title: 'An update is available 🎉',
+      title: `An update for ${app.getName()} is available 🎉`,
       body: 'Click here to install it 😊'
     });
 


### PR DESCRIPTION
Lessens reliance on recognising the iconography to identify where the notification originated from.