### PR TITLE
Improve copy on cancel export dialog

### DIFF
--- a/app/src/main/export.js
+++ b/app/src/main/export.js
@@ -22,8 +22,8 @@ export const startExport = () => {
     if (isExportInProgress) {
       const buttonIndex = dialog.showMessageBox(exportWindow, {
         type: 'question',
-        buttons: ['Cancel Export', 'Continue'],
-        defaultId: 1,
+        buttons: ['Cancel Export', 'Continue Export'],
+        defaultId: 0,
         cancelId: 1,
         message: 'Are you sure you want to cancel the export?'
       });


### PR DESCRIPTION
## What

Changes button text on cancel export modal

<img width="434" alt="screen shot 2018-03-25 at 19 03 04" src="https://user-images.githubusercontent.com/1028741/37878321-3316c7ca-305f-11e8-8389-341296bc77ef.png">


## Why

Closes https://github.com/wulkano/kap/issues/436