### PR TITLE
WIP: Add "Save Original" button

### DIFF
--- a/app/src/main/convert.js
+++ b/app/src/main/convert.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import {ipcMain} from 'electron';
 import tempy from 'tempy';
-import {convertToGif, convertToMp4, convertToWebm, convertToApng} from '../scripts/convert';
+import {convertToGif, convertToMp4, convertToWebm, convertToApng, trimOriginal} from '../scripts/convert';
 import {exportProgress} from './export';
 
 // `exportOptions` => format filePath width height fps loop, defaultFileName
@@ -13,6 +13,8 @@ export default async exportOptions => {
     convert = convertToGif;
   } else if (format === 'mp4') {
     convert = convertToMp4;
+  } else if (format === 'original') {
+    convert = trimOriginal;
   } else if (format === 'webm') {
     convert = convertToWebm;
   } else if (format === 'apng') {

--- a/app/src/main/plugins.js
+++ b/app/src/main/plugins.js
@@ -152,10 +152,19 @@ class Plugins {
       ['apng', 'APNG'],
       ['gif', 'GIF'],
       ['mp4', 'MP4'],
+      ['original', 'Original'],
       ['webm', 'WebM']
     ]);
 
     return formats.get(format);
+  }
+
+  formatExtension(format) {
+    if (format === 'original') {
+      return 'mp4';
+    }
+
+    return format;
   }
 }
 

--- a/app/src/main/save-file-service.js
+++ b/app/src/main/save-file-service.js
@@ -10,6 +10,8 @@ const action = async context => {
     filters = [{name: 'Movies', extensions: ['mp4']}];
   } else if (format === 'webm') {
     filters = [{name: 'Movies', extensions: ['webm']}];
+  } else if (format === 'original') {
+    filters = [{name: 'Movies', extensions: ['mp4']}];
   } else if (format === 'gif') {
     filters = [{name: 'Images', extensions: ['gif']}];
   } else {
@@ -58,6 +60,7 @@ export default {
   formats: [
     'gif',
     'mp4',
+    'original',
     'webm',
     'apng'
   ],

--- a/app/src/main/share-service-context.js
+++ b/app/src/main/share-service-context.js
@@ -9,9 +9,10 @@ export default class ShareServiceContext {
   constructor(exportOptions) {
     this.format = exportOptions.format;
     this.prettyFormat = plugins.prettifyFormat(this.format);
+    this.fileExtension = plugins.formatExtension(this.format);
 
     const now = moment();
-    this.defaultFileName = `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.${this.format}`;
+    this.defaultFileName = `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.${this.fileExtension}`;
 
     this.filePath = () => convert(Object.assign({}, exportOptions, {
       defaultFileName: this.defaultFileName

--- a/app/src/renderer/css/editor.css
+++ b/app/src/renderer/css/editor.css
@@ -212,16 +212,24 @@ section.output {
   }
 }
 
-.output-format {
+.output-format,
+.save-option {
   display: flex;
-  margin-right: 16px;
-  margin-left: auto;
   align-items: center;
 
   & > button:not(:first-child),
   & > .c-select:not(:first-child) {
     margin-right: 8px;
   }
+}
+
+.output-format {
+  margin-left: auto;
+}
+
+.save-option {
+  margin-left: 10px;
+  margin-right: 5px;
 }
 
 .fps,
@@ -235,7 +243,8 @@ section.output {
 
 .size > span,
 .fps > span,
-.output-format > span {
+.output-format > span,
+.save-option > span {
   display: flex;
   margin-right: 8px;
   align-items: center;

--- a/app/src/renderer/views/editor.pug
+++ b/app/src/renderer/views/editor.pug
@@ -68,3 +68,10 @@ block body
         .c-select__label APNG
         select
           option(selected disabled value="-1") Export Options
+      .save-option
+        span Save
+        button.button.button--dark.button--small-padding.hidden(data-export-type="original") Original
+        +select-custom(data-export-type="original").is-transparent.has-custom-label
+          .c-select__label Original
+          select
+            option(selected disabled value="-1") Export Options


### PR DESCRIPTION
## What

Adds `Save: Original` button.

## Why

Much faster export of long videos. Takes a couple of seconds to export gigabytes instead of hours.

## Why not

- The extra button may be avoidable
- This was partly an exercise for me to get used to an electron app, node.js and back into javascript
- This doesn't currently return the original file, but instead uses `ffmpeg` without FPS or resolution and adds in `-c copy` to get a much faster conversion. I'll probably close this and do two things instead:
  1. Ensure that export `mp4` omits FPS and dimensions when they are unchanged and uses `-c copy` instead.
  2. Depending on design in https://github.com/wulkano/kap/issues/429, add a save option somewhere which copies the file instead of using ffmpeg.

## Screenshot

<img width="777" alt="screen shot 2018-03-26 at 01 01 45" src="https://user-images.githubusercontent.com/1028741/37881517-5a773304-3091-11e8-8e90-c5559ef62307.png">

## Related

Closes https://github.com/wulkano/kap/issues/429