### PR TITLE
Fix fps undefined error

### DIFF
--- a/app/src/renderer/js/editor.js
+++ b/app/src/renderer/js/editor.js
@@ -33,8 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const trimmerOut = $('#trimmer-out');
   const trimLine = $('.timeline-markers');
 
-  let maxFps = app.kap.settings.get('fps');
-  maxFps = maxFps > 30 ? 30 : maxFps;
+  const maxFps = app.kap.settings.get('record60fps') ? 60 : 30;
   let fps = 15;
 
   let lastValidInputWidth;


### PR DESCRIPTION
Fixes #444

When we migrated from the `fps` slider to a `record60fps` toggle, we didn't change the way we read the setting in the editor. Everyone that had the app before the change, had the fps still set in their local settings, so the broken behavior wasn't obvious, but getting a new installation of kap would show undefined.