### PR TITLE
Fix dimension swapping

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -135,6 +135,8 @@ const openCropperWindow = (size = {}, position = {}, options = {}) => {
     cropperWindow = new BrowserWindow({
       width: width + cropperWindowBuffer,
       height: height + cropperWindowBuffer,
+      minHeight: 100 + cropperWindowBuffer,
+      minWidth: 100 + cropperWindowBuffer,
       frame: false,
       transparent: true,
       resizable: true,

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -269,7 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
     dimensions.width = parseInt(event.target.value, 10);
     app.kap.settings.set('dimensions', dimensions);
 
-    if (dimensions.ratioLocked) {
+    if (dimensions.ratioLocked && !event.detail.ignoreRatioLocked) {
       dimensions.height = Math.round((second / first) * event.target.value);
       app.kap.settings.set('dimensions', dimensions);
       inputHeight.value = dimensions.height;
@@ -302,7 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
     dimensions.height = parseInt(event.target.value, 10);
     app.kap.settings.set('dimensions', dimensions);
 
-    if (dimensions.ratioLocked) {
+    if (dimensions.ratioLocked && !event.detail.ignoreRatioLocked) {
       dimensions.width = Math.round((first / second) * event.target.value);
       app.kap.settings.set('dimensions', dimensions);
       inputWidth.value = dimensions.width;
@@ -341,8 +341,8 @@ document.addEventListener('DOMContentLoaded', () => {
   swapBtn.addEventListener('click', () => {
     [inputWidth.value, inputHeight.value] = [inputHeight.value, inputWidth.value];
     dimensions.ratio = dimensions.ratio.reverse();
-    inputWidth.dispatchEvent(new Event('input'));
-    inputHeight.dispatchEvent(new Event('input'));
+    inputWidth.dispatchEvent(new CustomEvent('input', {detail: {ignoreRatioLocked: true}}));
+    inputHeight.dispatchEvent(new CustomEvent('input', {detail: {ignoreRatioLocked: true}}));
     setSelectedRatio(dimensions.width, dimensions.height);
     app.kap.settings.set('dimensions', dimensions);
   });

--- a/app/src/renderer/js/main.js
+++ b/app/src/renderer/js/main.js
@@ -42,6 +42,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const [micOnIcon, micOffIcon] = toggleAudioRecordBtn.children;
 
   // Initial variables
+  const minWidth = 100;
+  const minHeight = 100;
   const dimensions = app.kap.settings.get('dimensions');
   const {width, height, ratioLocked} = dimensions;
   const dimensionsEmitter = new EventEmitter();
@@ -258,18 +260,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const [first, second] = dimensions.ratio;
 
+    const min = dimensions.ratioLocked ? Math.ceil(minHeight * first / second) : minWidth;
+    const max = dimensions.ratioLocked ? Math.ceil(screen.height * first / second) : screen.width;
+
     event.target.value = validateNumericInput(event.target, {
       lastValidValue: lastValidInputWidth,
       empty: !validate,
-      max: screen.width,
-      min: (validate && dimensions.ratioLocked) ? first : 1,
+      max: Math.min(max, screen.width),
+      min: Math.max(min, minWidth),
       onInvalid: shake
     });
 
     dimensions.width = parseInt(event.target.value, 10);
     app.kap.settings.set('dimensions', dimensions);
+    const ignoreRatioLocked = event.detail && event.detail.ignoreRatioLocked;
 
-    if (dimensions.ratioLocked && !event.detail.ignoreRatioLocked) {
+    if (dimensions.ratioLocked && !ignoreRatioLocked) {
       dimensions.height = Math.round((second / first) * event.target.value);
       app.kap.settings.set('dimensions', dimensions);
       inputHeight.value = dimensions.height;
@@ -291,18 +297,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const [first, second] = dimensions.ratio;
 
+    const min = dimensions.ratioLocked ? Math.ceil(minWidth * second / first) : minHeight;
+    const max = dimensions.ratioLocked ? Math.ceil(screen.width * second / first) : screen.height;
+
     event.target.value = validateNumericInput(event.target, {
       lastValidValue: lastValidInputHeight,
       empty: !validate,
-      max: screen.height - screen.availTop, // Currently we can't draw over the menubar
-      min: (validate && dimensions.ratioLocked) ? second : 1,
+      max: Math.min(max, screen.height),
+      min: Math.max(min, minHeight),
       onInvalid: shake
     });
 
     dimensions.height = parseInt(event.target.value, 10);
     app.kap.settings.set('dimensions', dimensions);
+    const ignoreRatioLocked = event.detail && event.detail.ignoreRatioLocked;
 
-    if (dimensions.ratioLocked && !event.detail.ignoreRatioLocked) {
+    if (dimensions.ratioLocked && !ignoreRatioLocked) {
       dimensions.width = Math.round((first / second) * event.target.value);
       app.kap.settings.set('dimensions', dimensions);
       inputWidth.value = dimensions.width;


### PR DESCRIPTION
Fixes #445

Ignores the ratio lock when swapping dimensions 

Also:
- Sets a min width and height of 100px (same for both)
   - Can't enter width or height less than 100
   - Can't resize (using the mouse) to smaller than 100x100
- When ratio is locked and changing one dimension, check if the other dimension (calculated based on the ratio) is invalid (too high or too low) and if it is, invalidate the change


#### To explain the last point:
If I have a ratio of 2:1, and it's locked, even though the min value for width is 100px, entering 100px would make the height 50px (based on the ratio), which is less than the height's minimum of 100px. So the real minimum of the width when locked to the 2:1 ratio is 200px (which would lead to a 100px height). 