### PR TITLE
Fix tray window opening on the wrong screen

### DIFF
--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -373,8 +373,8 @@ menubar.on('after-create-window', () => {
     recomputeExpectedWindowPosition();
     recomputeCurrentWindowPosition();
     if (expectedWindowPosition.x !== currentWindowPosition.x || expectedWindowPosition.y !== currentWindowPosition.y) { // This line is too long
-      menubar.setOption('x', currentWindowPosition.x);
-      menubar.setOption('y', currentWindowPosition.y);
+      menubar.setOption('x', expectedWindowPosition.x);
+      menubar.setOption('y', expectedWindowPosition.y);
     } else { // Reset the position if the window is back at it's original position
       menubar.setOption('x', undefined);
       menubar.setOption('y', undefined);


### PR DESCRIPTION
Fixes #365

I'm still familiarizing myself with the codebase, so I'm not entirely clear on the ramifications of this fix.

Tested using the binary and the expected behavior seems fairly consistent, although occasionally I noticed the menubar events will sometimes fall a little out of sync.

All in all, I really enjoy using this app, so I'm def looking forward to future API improvements.