### PR TITLE
Fix active cropper placement between displays

### DIFF
--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -24,7 +24,7 @@ const DEFAULTS = {
   }
 };
 
-const DEFAULT_VOLATILES = {
+const getDefaultVolatiles = () => ({
   cropperWindow: {
     size: {
       width: 512,
@@ -35,11 +35,11 @@ const DEFAULT_VOLATILES = {
       y: 'center'
     }
   }
-};
+});
 
 export const DEFAULT_CROPPER_WINDOW_POSITION = 'center';
 
-const volatiles = JSON.parse(JSON.stringify(DEFAULT_VOLATILES));
+const volatiles = getDefaultVolatiles();
 
 // We need to sync every setting that can be modified externally
 // e.g. the `openOnStartup` setting can be modified via
@@ -86,6 +86,6 @@ export const set = (key, value, {volatile = false} = {}) => {
 export const observe = (keyPath, handler) => settings.observe(keyPath, handler);
 
 export const reset = async keyPath => {
-  await settings.setSync(keyPath, objectPath.get(DEFAULT_VOLATILES, keyPath));
+  await settings.setSync(keyPath, objectPath.get(getDefaultVolatiles(), keyPath));
   objectPath.set(volatiles, keyPath, settings.getSync(keyPath));
 };

--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -83,3 +83,8 @@ export const set = (key, value, {volatile = false} = {}) => {
 };
 
 export const observe = (keyPath, handler) => settings.observe(keyPath, handler);
+
+export const reset = async (keyPath) => {
+  await settings.setSync(keyPath, objectPath.get(DEFAULT_VOLATILES, keyPath));
+  objectPath.set(volatiles, keyPath, settings.getSync(keyPath));
+};

--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -37,6 +37,7 @@ const DEFAULT_VOLATILES = {
   }
 };
 
+export const DEFAULT_CROPPER_WINDOW_POSITION = 'center';
 
 const volatiles = JSON.parse(JSON.stringify(DEFAULT_VOLATILES));
 

--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -85,7 +85,7 @@ export const set = (key, value, {volatile = false} = {}) => {
 
 export const observe = (keyPath, handler) => settings.observe(keyPath, handler);
 
-export const reset = async (keyPath) => {
+export const reset = async keyPath => {
   await settings.setSync(keyPath, objectPath.get(DEFAULT_VOLATILES, keyPath));
   objectPath.set(volatiles, keyPath, settings.getSync(keyPath));
 };

--- a/app/src/common/settings-manager.js
+++ b/app/src/common/settings-manager.js
@@ -24,7 +24,7 @@ const DEFAULTS = {
   }
 };
 
-const volatiles = {
+const DEFAULT_VOLATILES = {
   cropperWindow: {
     size: {
       width: 512,
@@ -36,6 +36,9 @@ const volatiles = {
     }
   }
 };
+
+
+const volatiles = JSON.parse(JSON.stringify(DEFAULT_VOLATILES));
 
 // We need to sync every setting that can be modified externally
 // e.g. the `openOnStartup` setting can be modified via

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -398,6 +398,7 @@ menubar.on('after-create-window', () => {
 
   let wasStuck = true;
   mainWindow.on('move', () => { // Unfortunately this is just an alias for 'moved'
+    settings.reset('cropperWindow.position');
     recomputeExpectedWindowPosition();
     recomputeCurrentWindowPosition();
     const diff = {

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -255,6 +255,18 @@ const recalculateCropperWindowPosition = () => {
   return positionWithBuffer;
 }
 
+const getDefaultCropperPosition = () => {
+  const { x, y } = settings.get('cropperWindow.position');
+  if (x === settings.DEFAULT_CROPPER_WINDOW_POSITION && y === settings.DEFAULT_CROPPER_WINDOW_POSITION) {
+    const newPosition = recalculateCropperWindowPosition();
+    return {
+      x: newPosition.x,
+      y: newPosition.y
+    };
+  }
+  return { x, y };
+}
+
 ipcMain.on('open-cropper-window', (event, size, position) => {
   if (cropperWindow) {
     cropperWindow.close();

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -141,7 +141,7 @@ const openCropperWindow = (size = {}, position = {}, options = {}) => {
     let {width = 512, height = 512} = settings.get('cropperWindow.size');
     width = size.width || width;
     height = size.height || height;
-    const { x, y } = position;
+    const {x, y} = position;
     cropperWindow = new BrowserWindow({
       width: width + cropperWindowBuffer,
       height: height + cropperWindowBuffer,
@@ -239,21 +239,21 @@ ipcMain.on('activate-app', async (event, appName, {width, height, x, y}) => {
 });
 
 const recalculateCropperWindowPosition = () => {
-  const { DEFAULT_CROPPER_WINDOW_POSITION } = settings;
+  const {DEFAULT_CROPPER_WINDOW_POSITION} = settings;
   const position = positioner.calculate(DEFAULT_CROPPER_WINDOW_POSITION, tray.getBounds());
   const positionWithBuffer = {
     x: position.x - (cropperWindowBuffer / 2),
     y: position.y - (cropperWindowBuffer / 2)
-  }
+  };
   settings.set('cropperWindow.position', {
     x: positionWithBuffer.x,
     y: positionWithBuffer.y
   });
   return positionWithBuffer;
-}
+};
 
 const getDefaultCropperPosition = () => {
-  const { x, y } = settings.get('cropperWindow.position');
+  const {x, y} = settings.get('cropperWindow.position');
   if (x === settings.DEFAULT_CROPPER_WINDOW_POSITION && y === settings.DEFAULT_CROPPER_WINDOW_POSITION) {
     const newPosition = recalculateCropperWindowPosition();
     return {
@@ -261,8 +261,8 @@ const getDefaultCropperPosition = () => {
       y: newPosition.y
     };
   }
-  return { x, y };
-}
+  return {x, y};
+};
 
 ipcMain.on('open-cropper-window', (event, size, position) => {
   if (cropperWindow) {

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -241,6 +241,20 @@ ipcMain.on('activate-app', async (event, appName, {width, height, x, y}) => {
   openCropperWindow({width, height}, {x, y}, {closeOnBlur: false});
 });
 
+const recalculateCropperWindowPosition = () => {
+  const { DEFAULT_CROPPER_WINDOW_POSITION } = settings;
+  const position = positioner.calculate(DEFAULT_CROPPER_WINDOW_POSITION, tray.getBounds());
+  const positionWithBuffer = {
+    x: position.x - (cropperWindowBuffer / 2),
+    y: position.y - (cropperWindowBuffer / 2)
+  }
+  settings.set('cropperWindow.position', {
+    x: positionWithBuffer.x,
+    y: positionWithBuffer.y
+  });
+  return positionWithBuffer;
+}
+
 ipcMain.on('open-cropper-window', (event, size, position) => {
   if (cropperWindow) {
     cropperWindow.close();

--- a/app/src/main/index.js
+++ b/app/src/main/index.js
@@ -141,9 +141,7 @@ const openCropperWindow = (size = {}, position = {}, options = {}) => {
     let {width = 512, height = 512} = settings.get('cropperWindow.size');
     width = size.width || width;
     height = size.height || height;
-    let {x, y} = settings.get('cropperWindow.position');
-    x = position.x === undefined ? x : position.x;
-    y = position.y === undefined ? y : position.y;
+    const { x, y } = position;
     cropperWindow = new BrowserWindow({
       width: width + cropperWindowBuffer,
       height: height + cropperWindowBuffer,
@@ -154,8 +152,7 @@ const openCropperWindow = (size = {}, position = {}, options = {}) => {
       resizable: true,
       hasShadow: false,
       enableLargerThanScreen: true,
-      x: x - (cropperWindowBuffer / 2),
-      y: y - (cropperWindowBuffer / 2)
+      ...position
     });
     mainWindow.webContents.send('cropper-window-opened', {width, height, x, y});
     cropperWindow.loadURL(`file://${__dirname}/../renderer/views/cropper.html`);
@@ -270,6 +267,10 @@ const getDefaultCropperPosition = () => {
 ipcMain.on('open-cropper-window', (event, size, position) => {
   if (cropperWindow) {
     cropperWindow.close();
+  }
+
+  if (!position) {
+    position = getDefaultCropperPosition();
   }
 
   openCropperWindow(size, position);


### PR DESCRIPTION
Fixes #131 for the most part

- cropper displays in the same window the tray icon was clicked
- works while tray menu's open
- works after moving and resizing cropper
- tested with binary

However, after moving cropper around in one window followed by re-opening it in another, the initial position becomes a little off, which probably has something to do with what's going on [here](https://github.com/wulkano/kap/blob/621f1cabc6ce859923a6c07536241d781454726d/app/src/main/index.js#L189-L217)

Also open to suggestions