### PR TITLE
Throw error when conversion fails so plugin action stops

### DIFF
--- a/main/export.js
+++ b/main/export.js
@@ -105,15 +105,9 @@ class Export {
       this.format
     );
 
-    try {
-      const filePath = await this.convertProcess;
-      this.resolve();
-      return filePath;
-    } catch (error) {
-      if (!this.convertProcess.isCanceled) {
-        this.reject(error);
-      }
-    }
+    const filePath = await this.convertProcess;
+    this.resolve();
+    return filePath;
   }
 }
 


### PR DESCRIPTION
Currently if an error occurs in the ffmpeg conversion the error is caught, so the rest of the plugin action continues to execute. Most of the time it's silent and the convert doesn't fail so it was hard to notice, but if it fails with something like `draggable` you still get the window open, or with something like giphy, it still tries to upload.

This lets the conversion throw the error instead of catching it, since it is being caught further up. Tested it and it still shows as `Failed` in the export window but the action is also stopped