### PR TITLE
Clear plugin config on uninstall

### DIFF
--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -129,6 +129,8 @@ class Plugins {
     this._modifyMainPackageJson(pkg => {
       delete pkg.dependencies[name];
     });
+    const plugin = new Plugin(name);
+    plugin.config.clear();
   }
 
   async prune() {


### PR DESCRIPTION
Make sure the config is cleared when a plugin is uninstalled