### PR TITLE
Fix desktop icons and do not disturb behavior

### DIFF
--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -15,7 +15,7 @@ const aperture = createAperture();
 const {audioDevices} = createAperture;
 
 let wasDoNotDisturbAlreadyEnabled;
-let lastRecordedFps;
+let lastUsedSettings;
 
 let past;
 
@@ -46,7 +46,11 @@ const startRecording = async options => {
     displayId: String(displayId)
   };
 
-  lastRecordedFps = apertureOpts.fps;
+  lastUsedSettings = {
+    recordedFps: apertureOpts.fps,
+    hideDesktopIcons,
+    doNotDisturb
+  };
 
   if (recordAudio === true) {
     // In case for some reason the default audio device is not set
@@ -110,9 +114,10 @@ const stopRecording = async () => {
   const filePath = await aperture.stopRecording();
 
   const {
+    recordedFps,
     hideDesktopIcons,
     doNotDisturb
-  } = settings.store;
+  } = lastUsedSettings;
 
   if (hideDesktopIcons) {
     desktopIcons.show();
@@ -123,7 +128,7 @@ const stopRecording = async () => {
   }
 
   track('editor/opened/recording');
-  openEditorWindow(filePath, lastRecordedFps);
+  openEditorWindow(filePath, recordedFps);
 };
 
 module.exports = {


### PR DESCRIPTION
We can save what the setting was when we start recording and use that when we stop, instead of pulling it from the store again, to avoid mismatch if the settings changed mid-recording.

This way we don't have to hide the Preferences window