### PR TITLE
Tweak analytics

### DIFF
--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -96,7 +96,7 @@ const startRecording = async options => {
     setRecordingTray(stopRecording);
     past = Date.now();
   } catch (error) {
-    track('recording/stoppped/error');
+    track('recording/stopped/error');
     // This prevents the button from being reset, since the recording has not yet started
     // This delay is due to internal framework delays in aperture native code
     if (error.message.includes('stopRecording')) {
@@ -110,7 +110,7 @@ const startRecording = async options => {
 
 const stopRecording = async () => {
   console.log(`Stopped recording after ${(Date.now() - past) / 1000}s`);
-  track('recording/stoppped');
+  track('recording/stopped');
   closeAllCroppers();
 
   const filePath = await aperture.stopRecording();

--- a/main/convert.js
+++ b/main/convert.js
@@ -20,14 +20,14 @@ const frameRegex = /frame=\s+(\d+)/gm;
 const makeEven = n => 2 * Math.round(n / 2);
 
 const convert = (outputPath, opts, args) => {
-  track(`file/exported/fps/${opts.fps}`);
+  track(`file/export/fps/${opts.fps}`);
 
   return new PCancelable((resolve, reject, onCancel) => {
     const converter = execa(ffmpegPath, args);
     let amountOfFrames;
 
     onCancel(() => {
-      track('file/exported/convert/canceled');
+      track('file/export/convert/canceled');
       converter.kill();
     });
 
@@ -52,10 +52,10 @@ const convert = (outputPath, opts, args) => {
 
     converter.on('exit', code => {
       if (code === 0) {
-        track('file/exported/convert/completed');
+        track('file/export/convert/completed');
         resolve(outputPath);
       } else {
-        track('file/exported/convert/failed');
+        track('file/export/convert/failed');
         reject(new Error(`ffmpeg exited with code: ${code}\n\n${stderr}`));
       }
     });
@@ -166,7 +166,7 @@ const convertTo = (opts, format) => {
   const outputPath = path.join(tempy.directory(), opts.defaultFileName);
   const converter = converters.get(format);
   opts.onProgress(0);
-  track(`file/exported/format/${format}`);
+  track(`file/export/format/${format}`);
 
   return converter({outputPath, ...opts});
 };

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -2,6 +2,8 @@ import electron from 'electron';
 import {Container} from 'unstated';
 import delay from 'delay';
 
+const SETTINGS_ANALYTICS_BLACKLIST = ['kapturesDir'];
+
 export default class PreferencesContainer extends Container {
   remote = electron.remote || false;
 
@@ -126,7 +128,9 @@ export default class PreferencesContainer extends Container {
     // TODO: Fix this ESLint violation
     // eslint-disable-next-line react/no-access-state-in-setstate
     const newVal = value === undefined ? !this.state[setting] : value;
-    this.track(`preferences/setting/${setting}/${newVal}`);
+    if (!SETTINGS_ANALYTICS_BLACKLIST.includes(setting)) {
+      this.track(`preferences/setting/${setting}/${newVal}`);
+    }
     this.setState({[setting]: newVal});
     this.settings.set(setting, newVal);
   }


### PR DESCRIPTION
- /v3.0/recording/stoppped > stopped*
- ~/v3.0/export/canceled/current > cancelled*~
- ~/v3.0/file/exported/convert/canceled > export* cancelled*~
- ~/v3.0/export/canceled/waiting > cancelled*~
- All instances off "exported" > export 
- Blacklist `kapturesDir` from tracking

I don't think we should change from `canceled` to `cancelled`, we spell it as `canceled` consistently in the code.