### PR TITLE
Add support for Mojave dark mode for native components

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
       "category": "public.app-category.productivity",
       "minimumSystemVersion": "10.12.0",
       "extendInfo": {
+        "NSRequiresAquaSystemAppearance": false,
         "NSUserNotificationAlertStyle": "alert",
         "CFBundleDocumentTypes": [
           {


### PR DESCRIPTION
Mostly the export save window and native titlebars and menus.

<img width="887" alt="screen shot 2018-10-04 at 13 42 51" src="https://user-images.githubusercontent.com/170270/46457204-b0a26c80-c7db-11e8-9e02-a9aa7567349b.png">
<img width="622" alt="screen shot 2018-10-04 at 13 45 26" src="https://user-images.githubusercontent.com/170270/46457222-c44dd300-c7db-11e8-917d-65bdae2f7fc3.png">

It makes the about window look weird, but we plan to fix this soon with #478:

<img width="396" alt="screen shot 2018-10-04 at 13 46 09" src="https://user-images.githubusercontent.com/170270/46457253-dcbded80-c7db-11e8-82a5-879a37fde18e.png">
