### PR TITLE
Issue #565: Title not centered

### DIFF
--- a/renderer/components/editor/index.js
+++ b/renderer/components/editor/index.js
@@ -66,6 +66,7 @@ export default class Editor extends React.Component {
             justify-content: center;
             font-size: 1.4rem;
             color: #fff;
+            margin-left: -72px;
           }
         `}</style>
       </div>


### PR DESCRIPTION
Add margin-left: -72px to make title ignore the size of traffic lights plus the margins associated with the traffic light

The total size of traffic light (image + margins) is 72px thus the -72px.

Another option is to make the title have position: absolute and give it a negative z-index to make sure it doesn't mess with the traffic lights.

The final result:
<img width="768" alt="screen shot 2018-10-04 at 5 44 03 pm" src="https://user-images.githubusercontent.com/17018996/46510470-07b93900-c7fe-11e8-823f-44723abb7718.png">
