### PR TITLE
Position menu above IconMenu near screen bottom

### DIFF
--- a/renderer/components/action-bar/controls/main.js
+++ b/renderer/components/action-bar/controls/main.js
@@ -54,7 +54,7 @@ class Left extends React.Component {
         <div className="crop">
           <CropIcon onClick={toggleAdvanced}/>
         </div>
-        <IconMenu onOpen={menu && menu.popup}><ApplicationsIcon active={Boolean(selectedApp)}/></IconMenu>
+        <IconMenu itemCount={menu && menu.items.length} onOpen={menu && menu.popup}><ApplicationsIcon active={Boolean(selectedApp)}/></IconMenu>
         <style jsx>{mainStyle}</style>
         <style jsx>{`
           .crop {
@@ -87,6 +87,7 @@ MainControls.Left = connect(
 class Right extends React.Component {
   render() {
     const {enterFullscreen, exitFullscreen, isFullscreen} = this.props;
+    const {cogMenu} = electron.remote.require('./menus');
 
     return (
       <div className="main">
@@ -97,7 +98,7 @@ class Right extends React.Component {
               <FullscreenIcon onClick={enterFullscreen}/>
           }
         </div>
-        <IconMenu onOpen={electron.remote.require('./menus').cogMenu.popup}><MoreIcon/></IconMenu>
+        <IconMenu itemCount={cogMenu.items.length} onOpen={cogMenu.popup}><MoreIcon/></IconMenu>
         <style jsx>{mainStyle}</style>
         <style jsx>{`
           .fullscreen {

--- a/renderer/components/icon-menu.js
+++ b/renderer/components/icon-menu.js
@@ -1,19 +1,26 @@
+import electron from 'electron';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const MENU_UP_THRESHOLD = 60;
+
 class IconMenu extends React.Component {
+  remote = electron.remote || false
+
   container = React.createRef();
 
   openMenu = event => {
     const boundingRect = this.container.current.getBoundingClientRect();
-    const {bottom, left} = boundingRect;
+    const {screen} = this.remote;
+    const {bottom, left, top} = boundingRect;
+    const {height: screenHeight} = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
     const {onOpen} = this.props;
     event.stopPropagation();
 
     if (onOpen) {
       onOpen({
         x: Math.round(left),
-        y: Math.round(bottom)
+        y: Math.round(screenHeight - bottom < MENU_UP_THRESHOLD ? top : bottom)
       });
     }
   }

--- a/renderer/components/icon-menu.js
+++ b/renderer/components/icon-menu.js
@@ -2,7 +2,7 @@ import electron from 'electron';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const MENU_UP_THRESHOLD = 60;
+const MENU_UP_THRESHOLD = 100;
 
 class IconMenu extends React.Component {
   remote = electron.remote || false
@@ -10,17 +10,20 @@ class IconMenu extends React.Component {
   container = React.createRef();
 
   openMenu = event => {
+    const {itemCount} = this.props;
     const boundingRect = this.container.current.getBoundingClientRect();
     const {screen} = this.remote;
-    const {bottom, left, top} = boundingRect;
+    const {bottom, left, top, height} = boundingRect;
     const {height: screenHeight} = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
     const {onOpen} = this.props;
+    const willOpenUp = screenHeight - bottom < MENU_UP_THRESHOLD;
     event.stopPropagation();
 
     if (onOpen) {
       onOpen({
         x: Math.round(left),
-        y: Math.round(screenHeight - bottom < MENU_UP_THRESHOLD ? top : bottom)
+        y: Math.round(willOpenUp ? top - height : bottom),
+        positioningItem: willOpenUp ? itemCount - 1 : -1
       });
     }
   }
@@ -45,7 +48,8 @@ IconMenu.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
-  ]).isRequired
+  ]).isRequired,
+  itemCount: PropTypes.number
 };
 
 export default IconMenu;


### PR DESCRIPTION
Attempts to fix #563 but since electron provides no control or feedback for whether the menu will display above or below this approach isn't perfect.

It works just fine when all the way at the bottom of the screen:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/2533/46578694-9d99c300-c9ba-11e8-96cf-0159c5ea535f.png">

The issue is that if we check the position compared to the bottom of the screen in an attempt to guess if the menu will display upwards, then we move the menu attachment up to the top of the bounding rect of the IconMenu, we've now given the menu more space to display downwards and it may decide to use that and display downwards still, once again covering the IconMenu component.

Example:
<img width="615" alt="image" src="https://user-images.githubusercontent.com/2533/46578738-06813b00-c9bb-11e8-93e9-6e9a5fdc3cb5.png">

The threshold I've set this to attempts to make the amount of space this could possible happen in either direction as small as possible, but it is still possible.