### PR TITLE
Close export window if not open already

### DIFF
--- a/main/export-list.js
+++ b/main/export-list.js
@@ -101,7 +101,7 @@ class ExportList {
   }
 
   async addExport(options) {
-    const exportWindowVisible = getExportsWindow().isVisible(); // Check if export window is visible
+    const isExportsWindowVisible = getExportsWindow().isVisible();
     toggleExportMenuItem(true);
     options.exportOptions.loop = settings.get('loopExports');
     const newExport = new Export(options);
@@ -123,7 +123,7 @@ class ExportList {
       if (filePath) {
         newExport.context.targetFilePath = filePath;
       } else {
-        if (!exportWindowVisible) { // Don't close exports window if visible already
+        if (!isExportsWindowVisible) {
           closeExportsWindow();
         }
         return;

--- a/main/export-list.js
+++ b/main/export-list.js
@@ -13,7 +13,7 @@ const makeDir = require('make-dir');
 const settings = require('./common/settings');
 const {track} = require('./common/analytics');
 const {openPrefsWindow} = require('./preferences');
-const {showExportsWindow, getExportsWindow, openExportsWindow} = require('./exports');
+const {showExportsWindow, getExportsWindow, openExportsWindow, closeExportsWindow} = require('./exports');
 const {openEditorWindow} = require('./editor');
 const {toggleExportMenuItem} = require('./menus');
 const Export = require('./export');
@@ -101,6 +101,7 @@ class ExportList {
   }
 
   async addExport(options) {
+    const exportWindowVisible = getExportsWindow().isVisible(); // check if export window is visible
     toggleExportMenuItem(true);
     options.exportOptions.loop = settings.get('loopExports');
     const newExport = new Export(options);
@@ -122,6 +123,7 @@ class ExportList {
       if (filePath) {
         newExport.context.targetFilePath = filePath;
       } else {
+        !exportWindowVisible && closeExportsWindow(); // don't close exports window if visible already
         return;
       }
     }

--- a/main/export-list.js
+++ b/main/export-list.js
@@ -101,7 +101,7 @@ class ExportList {
   }
 
   async addExport(options) {
-    const exportWindowVisible = getExportsWindow().isVisible(); // check if export window is visible
+    const exportWindowVisible = getExportsWindow().isVisible(); // Check if export window is visible
     toggleExportMenuItem(true);
     options.exportOptions.loop = settings.get('loopExports');
     const newExport = new Export(options);
@@ -123,7 +123,9 @@ class ExportList {
       if (filePath) {
         newExport.context.targetFilePath = filePath;
       } else {
-        !exportWindowVisible && closeExportsWindow(); // don't close exports window if visible already
+        if (!exportWindowVisible) { // Don't close exports window if visible already
+          closeExportsWindow();
+        }
         return;
       }
     }

--- a/main/exports.js
+++ b/main/exports.js
@@ -30,6 +30,12 @@ const openExportsWindow = show => {
   }
 };
 
+const closeExportsWindow = () => {
+  if (exportsWindow) {
+    exportsWindow.close();
+  }
+};
+
 const getExportsWindow = () => exportsWindow;
 
 const showExportsWindow = () => {
@@ -53,5 +59,6 @@ app.on('before-quit', () => {
 module.exports = {
   openExportsWindow,
   getExportsWindow,
+  closeExportsWindow,
   showExportsWindow
 };


### PR DESCRIPTION
Fixes #560 

Issue: When we click the "Export" button in the Editor, and then hit "Cancel," it should close the export window if it was not open already.

It seemed that in the code we never explicitly close the export window but rather we hide it. The way I went about it was to check if the export window was hidden when the "Export" button was clicked and if it was hidden (indicating that it was not open previously or closed previously), then on "Cancel" click, it would close the exports window.

**If exports window was not open previously**
![cancelclick_notopen](https://user-images.githubusercontent.com/17018996/46912513-bf9bc400-cf2b-11e8-9136-165ff85376e2.gif)

**If exports window was open previously**
![cancel_open](https://user-images.githubusercontent.com/17018996/46912521-f07bf900-cf2b-11e8-9850-d646fd8824ba.gif)
