### PR TITLE
[#576] Remove un-needed 'min' value in editor container

### DIFF
--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -41,10 +41,9 @@ export default class EditorContainer extends Container {
 
     if (value.match(/^\d+$/)) {
       const val = parseInt(value, 10);
+      const min = 1;
 
       if (name === 'width') {
-        const min = Math.max(1, Math.ceil(ratio));
-
         if (val < min) {
           shake(target, {className: 'shake-left'});
           updates.width = min;
@@ -57,8 +56,6 @@ export default class EditorContainer extends Container {
 
         updates.height = Math.round(updates.width / ratio);
       } else {
-        const min = Math.max(1, Math.ceil(1 / ratio));
-
         if (val < min) {
           shake(target, {className: 'shake-right'});
           updates.height = min;


### PR DESCRIPTION
The height and width boxes were being bound to a lower value based on the ratio which was preventing users from inputting certain values that were lower than the ratio calculated from the other field. This change sets the min to be 1, and lets the other value be calculated based on the ratio as normal. Fixes #576 