### PR TITLE
Add keyboard control to editor and refactor into shared component

### DIFF
--- a/renderer/components/action-bar/controls/advanced.js
+++ b/renderer/components/action-bar/controls/advanced.js
@@ -15,9 +15,12 @@ import {
   handleWidthInput,
   handleHeightInput,
   buildAspectRatioMenu,
-  handleInputKeyPress,
+  minHeight,
+  minWidth,
   RATIOS
 } from '../../../utils/inputs';
+
+import KeyboardNumberInput from '../../keyboard-number-input';
 
 const advancedStyles = css`
   .advanced {
@@ -26,6 +29,25 @@ const advancedStyles = css`
     flex: 1;
     align-items: center;
     padding: 0 8px;
+  }
+`;
+
+const {className: keyboardInputClass, styles: keyboardInputStyles} = css.resolve`
+  height: 32px;
+  border: 1px solid #ddd;
+  background: white;
+  text-align: left;
+  font-size: 12px;
+  transition: border 0.12s ease-in-out;
+  box-sizing: border-box;
+  padding: 8px;
+  border-radius: 4px;
+  margin-right: 8px;
+  width: 64px;
+
+  :focus {
+    outline: none;
+    border: 1px solid #007aff;
   }
 `;
 
@@ -81,6 +103,7 @@ class Left extends React.Component {
         <div className="link">
           <LinkIcon active={ratioLocked} onClick={() => toggleRatioLock()}/>
         </div>
+        {keyboardInputStyles}
         <style jsx>{advancedStyles}</style>
         <style jsx>{`
           .back {
@@ -197,56 +220,41 @@ class Right extends React.Component {
   }
 
   render() {
-    const {swapDimensions, width, height} = this.props;
+    const {swapDimensions, width, height, screenWidth, screenHeight} = this.props;
 
     return (
       <div className="advanced">
-        <input
+        <KeyboardNumberInput
           ref={this.widthInput}
-          type="text"
+          className={keyboardInputClass}
           name="width"
           size="5"
+          min={minWidth}
+          max={screenWidth}
           maxLength="5"
           value={width}
           onChange={this.onWidthChange}
           onBlur={this.onWidthBlur}
-          onKeyDown={handleInputKeyPress(this.onWidthChange)}
+          onKeyDown={this.onWidthChange}
           onMouseDown={stopPropagation}/>
         <div className="swap">
           <SwapIcon onClick={swapDimensions}/>
         </div>
-        <input
+        <KeyboardNumberInput
           ref={this.heightInput}
-          type="text"
+          className={keyboardInputClass}
           name="height"
           size="5"
+          min={minHeight}
+          max={screenHeight}
           maxLength="5"
           value={height}
           onChange={this.onHeightChange}
           onBlur={this.onHeightBlur}
-          onKeyDown={handleInputKeyPress(this.onHeightChange)}
+          onKeyDown={this.onHeightChange}
           onMouseDown={stopPropagation}/>
         <style jsx>{advancedStyles}</style>
         <style jsx>{`
-          input {
-            height: 32px;
-            border: 1px solid #ddd;
-            background: white;
-            text-align: left;
-            font-size: 12px;
-            transition: border 0.12s ease-in-out;
-            box-sizing: border-box;
-            padding: 8px;
-            border-radius: 4px;
-            margin-right: 8px;
-            width: 64px;
-          }
-
-          input:focus {
-            outline: none;
-            border: 1px solid #007aff;
-          }
-
           .swap {
             width: 32px;
             height: 32px;
@@ -271,15 +279,19 @@ Right.propTypes = {
   setBounds: PropTypes.func.isRequired,
   swapDimensions: PropTypes.func.isRequired,
   setWidth: PropTypes.func.isRequired,
-  setHeight: PropTypes.func.isRequired
+  setHeight: PropTypes.func.isRequired,
+  screenWidth: PropTypes.number,
+  screenHeight: PropTypes.number
 };
 
 AdvancedControls.Right = connect(
   [CropperContainer, ActionBarContainer],
   (
-    {x, y, ratio, width, height},
+    {x, y, ratio, width, height, screenWidth, screenHeight},
     {cropperWidth, cropperHeight, ratioLocked}
   ) => ({
+    screenHeight,
+    screenWidth,
     bounds: {x, y, width, height},
     width: cropperWidth,
     height: cropperHeight,

--- a/renderer/components/editor/options/left.js
+++ b/renderer/components/editor/options/left.js
@@ -1,8 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import css from 'styled-jsx/css';
 import {connect, EditorContainer} from '../../../containers';
+import {minHeight, minWidth} from '../../../utils/inputs';
+import KeyboardNumberInput from '../../keyboard-number-input';
 import Slider from './slider';
+
+const {className: keyboardInputClass, styles: keyboardInputStyles} = css.resolve`
+  height: 24px;
+  background: hsla(0, 0%, 100%, 0.1);
+  text-align: center;
+  font-size: 12px;
+  box-sizing: border-box;
+  border: none;
+  padding: 4px;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  width: 48px;
+  color: white;
+
+  input + input {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 4px;
+    border-top-right-radius: 4px;
+    margin-left: 1px;
+    margin-right: 16px;
+  }
+
+  :focus, :hover {
+    outline: none;
+    background: hsla(0, 0%, 100%, 0.2);
+  }
+`;
 
 class LeftOptions extends React.Component {
   handleBlur = event => {
@@ -11,33 +41,40 @@ class LeftOptions extends React.Component {
   }
 
   render() {
-    const {width, height, changeDimension, fps, originalFps, setFps} = this.props;
+    const {width, height, changeDimension, fps, originalFps, setFps, original} = this.props;
 
     return (
       <div className="container">
         <div className="label">Size</div>
-        <input
-          type="text"
+        <KeyboardNumberInput
+          className={keyboardInputClass}
           value={width || ''}
           size="5"
           maxLength="5"
+          min={minWidth}
+          max={original && original.width}
           name="width"
           onChange={changeDimension}
+          onKeyDown={changeDimension}
           onBlur={this.handleBlur}
         />
-        <input
-          type="text"
+        <KeyboardNumberInput
+          className={keyboardInputClass}
           value={height || ''}
           size="5"
           maxLength="5"
+          min={minHeight}
+          max={original && original.height}
           name="height"
           onChange={changeDimension}
+          onKeyDown={changeDimension}
           onBlur={this.handleBlur}
         />
         <div className="label">FPS</div>
         <div className="fps">
           <Slider value={fps} min={1} max={originalFps} onChange={setFps}/>
         </div>
+        {keyboardInputStyles}
         <style jsx>{`
           .container {
             height: 100%;
@@ -54,34 +91,6 @@ class LeftOptions extends React.Component {
           .fps {
             height: 24px;
             width: 32px;
-          }
-
-          input {
-            height: 24px;
-            background: hsla(0, 0%, 100%, 0.1);
-            text-align: center;
-            font-size: 12px;
-            box-sizing: border-box;
-            border: none;
-            padding: 4px;
-            border-bottom-left-radius: 4px;
-            border-top-left-radius: 4px;
-            width: 48px;
-            color: white;
-          }
-
-          input + input {
-            border-bottom-left-radius: 0;
-            border-top-left-radius: 0;
-            border-bottom-right-radius: 4px;
-            border-top-right-radius: 4px;
-            margin-left: 1px;
-            margin-right: 16px;
-          }
-
-          input:focus, input:hover {
-            outline: none;
-            background: hsla(0, 0%, 100%, 0.2);
           }
 
           .option {
@@ -116,11 +125,15 @@ LeftOptions.propTypes = {
   changeDimension: PropTypes.func,
   fps: PropTypes.number,
   setFps: PropTypes.func,
-  originalFps: PropTypes.number
+  originalFps: PropTypes.number,
+  original: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number
+  })
 };
 
 export default connect(
   [EditorContainer],
-  ({width, height, fps, originalFps}) => ({width, height, fps, originalFps}),
+  ({width, height, fps, originalFps, original}) => ({width, height, fps, originalFps, original}),
   ({changeDimension, setFps}) => ({changeDimension, setFps})
 )(LeftOptions);

--- a/renderer/components/keyboard-number-input.js
+++ b/renderer/components/keyboard-number-input.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {handleInputKeyPress} from '../utils/inputs';
+
+class KeyboardNumberInput extends React.Component {
+  render() {
+    const {onKeyDown, min, max, ...rest} = this.props;
+
+    return (
+      <input {...rest} type="text" onKeyDown={handleInputKeyPress(onKeyDown, min, max)}/>
+    );
+  }
+}
+
+KeyboardNumberInput.propTypes = {
+  onKeyDown: PropTypes.func,
+  min: PropTypes.number,
+  max: PropTypes.number
+};
+
+export default KeyboardNumberInput;

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -1,8 +1,7 @@
 import electron from 'electron';
 import {Container} from 'unstated';
 import moment from 'moment';
-
-import {shake} from '../utils/inputs';
+import {shake, minHeight, minWidth} from '../utils/inputs';
 
 const isMuted = format => ['gif', 'apng'].includes(format);
 
@@ -29,8 +28,8 @@ export default class EditorContainer extends Container {
 
   changeDimension = (event, {ignoreEmpty = true} = {}) => {
     const {ratio, original, lastValid = {}} = this.state;
-    const {target} = event;
-    const {name, value} = target;
+    const {currentTarget} = event;
+    const {name, value} = currentTarget;
     const updates = {...lastValid, lastValid: null};
 
     if (value === '' && ignoreEmpty) {
@@ -41,14 +40,13 @@ export default class EditorContainer extends Container {
 
     if (value.match(/^\d+$/)) {
       const val = parseInt(value, 10);
-      const min = 1;
 
       if (name === 'width') {
-        if (val < min) {
-          shake(target, {className: 'shake-left'});
-          updates.width = min;
+        if (val < minWidth) {
+          shake(currentTarget, {className: 'shake-left'});
+          updates.width = minWidth;
         } else if (val > original.width) {
-          shake(target, {className: 'shake-left'});
+          shake(currentTarget, {className: 'shake-left'});
           updates.width = original.width;
         } else {
           updates.width = val;
@@ -56,11 +54,11 @@ export default class EditorContainer extends Container {
 
         updates.height = Math.round(updates.width / ratio);
       } else {
-        if (val < min) {
-          shake(target, {className: 'shake-right'});
-          updates.height = min;
+        if (val < minHeight) {
+          shake(currentTarget, {className: 'shake-right'});
+          updates.height = minHeight;
         } else if (val > original.height) {
-          shake(target, {className: 'shake-right'});
+          shake(currentTarget, {className: 'shake-right'});
           updates.height = original.height;
         } else {
           updates.height = val;
@@ -69,9 +67,9 @@ export default class EditorContainer extends Container {
         updates.width = Math.round(updates.height * ratio);
       }
     } else if (name === 'width') {
-      shake(target, {className: 'shake-left'});
+      shake(currentTarget, {className: 'shake-left'});
     } else {
-      shake(target, {className: 'shake-right'});
+      shake(currentTarget, {className: 'shake-right'});
     }
 
     this.setState(updates);

--- a/renderer/utils/inputs.js
+++ b/renderer/utils/inputs.js
@@ -172,16 +172,17 @@ const buildAspectRatioMenu = ({setRatio, ratio}) => {
   return menu;
 };
 
-const handleInputKeyPress = onChange => event => {
+const handleInputKeyPress = (onChange, min, max) => event => {
   const multiplier = event.shiftKey ? 10 : 1;
   const parsedValue = parseInt(event.currentTarget.value, 10);
-  const [min, max] = event.currentTarget.name === 'width' ? [minWidth, screenWidth] : [minHeight, screenHeight];
 
   // Fake an onChange event
   if (event.key === 'ArrowUp') {
-    onChange({currentTarget: {value: `${Math.min(parsedValue + multiplier, max)}`}});
+    event.currentTarget.value = `${Math.min(parsedValue + multiplier, max)}`;
+    onChange(event);
   } else if (event.key === 'ArrowDown') {
-    onChange({currentTarget: {value: `${Math.max(parsedValue - multiplier, min)}`}});
+    event.currentTarget.value = `${Math.max(parsedValue - multiplier, min)}`;
+    onChange(event);
   }
 
   // Don't let shift key lock aspect ratio


### PR DESCRIPTION
This PR closes #562 and does the following - 

* Creates a shared component `KeyboardNumberInput` which uses the `onKeyDown` event to change the input value using the arrow keys. This uses the existing `handleInputKeyPress` with some tweaking. The component takes `min, max and onKeyDown` as props
* Updates `handleInputKeyPress` to accept `min, max` as parameters to make it less opinionated and usable in both the cropper and the editor
* Sets the `min,max` values in the cropper to be the `minHeight` and `minWidth` values in the `utils/inputs.js` and the screen height/width
* Sets the `mix,max` values in the editor to be the `minHeight` and `minWidth` values in the `utils/inputs.js` and the original height/width