### PR TITLE
Add a separator after the `About` menu item

### DIFF
--- a/main/menus.js
+++ b/main/menus.js
@@ -41,6 +41,9 @@ const cogMenuTemplate = [
     click: openAboutWindow
   },
   {
+    type: 'separator'
+  },
+  {
     label: 'Send Feedback…',
     click: () => shell.openExternal(`https://github.com/wulkano/kap/issues/new?body=${encodeURIComponent(issueBody)}`)
   },


### PR DESCRIPTION
To adhere to the macOS human interface guidelines:

> Separate the About menu item and display it first. Include a separator after the About menu item and don’t group it with other items.

https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-bar-menus/