### PR TITLE
Hide the "show cursor" option on macOS High Sierra

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "insight": "^0.10.1",
     "lodash": "^4.17.10",
     "mac-windows": "^0.7.1",
+    "macos-version": "^4.1.0",
     "make-dir": "^1.3.0",
     "moment": "^2.22.2",
     "move-file": "^1.0.0",

--- a/renderer/components/preferences/categories/settings.js
+++ b/renderer/components/preferences/categories/settings.js
@@ -2,6 +2,7 @@ import electron from 'electron';
 import React from 'react';
 import PropTypes from 'prop-types';
 import tildify from 'tildify';
+import macosVersion from 'macos-version';
 
 import {connect, PreferencesContainer} from '../../../containers';
 
@@ -12,6 +13,8 @@ import Select from '../item/select';
 import ShortcutInput from '../shortcut-input';
 
 import Category from './category';
+
+const showCursorNotSupported = macosVersion.is('>=10.13 <10.14');
 
 class Settings extends React.Component {
   static defaultProps = {
@@ -62,9 +65,11 @@ class Settings extends React.Component {
           parentItem
           title="Show cursor"
           subtitle="Display the mouse cursor in your Kaptures"
+          errors={showCursorNotSupported ? ['Not supported on MacOS High Sierra'] : null}
         >
           <Switch
             checked={showCursor}
+            disabled={showCursorNotSupported}
             onClick={
               () => {
                 if (showCursor) {

--- a/renderer/components/preferences/categories/settings.js
+++ b/renderer/components/preferences/categories/settings.js
@@ -14,7 +14,7 @@ import ShortcutInput from '../shortcut-input';
 
 import Category from './category';
 
-const showCursorNotSupported = macosVersion.is('>=10.13 <10.14');
+const showCursorSupported = macosVersion.isGreaterThanOrEqualTo('10.14');
 
 class Settings extends React.Component {
   static defaultProps = {
@@ -61,24 +61,23 @@ class Settings extends React.Component {
 
     return (
       <Category>
-        <Item
-          parentItem
-          title="Show cursor"
-          subtitle="Display the mouse cursor in your Kaptures"
-          errors={showCursorNotSupported ? ['Not supported on MacOS High Sierra'] : null}
-        >
-          <Switch
-            checked={showCursor}
-            disabled={showCursorNotSupported}
-            onClick={
-              () => {
-                if (showCursor) {
-                  toggleSetting('highlightClicks', false);
+        {showCursorSupported && (
+          <Item
+            parentItem
+            title="Show cursor"
+            subtitle="Display the mouse cursor in your Kaptures"
+          >
+            <Switch
+              checked={showCursor}
+              onClick={
+                () => {
+                  if (showCursor) {
+                    toggleSetting('highlightClicks', false);
+                  }
+                  toggleSetting('showCursor');
                 }
-                toggleSetting('showCursor');
-              }
-            }/>
-        </Item>
+              }/>
+          </Item>)}
         <Item subtitle="Highlight clicks">
           <Switch
             checked={highlightClicks}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,7 +5478,7 @@ macos-release@^1.0.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
   integrity sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==
 
-macos-version@^4.0.1:
+macos-version@^4.0.1, macos-version@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/macos-version/-/macos-version-4.1.0.tgz#028e44adb28037e50395e2285bef054ef9b08ffa"
   integrity sha1-Ao5ErbKAN+UDleIoW+8FTvmwj/o=
@@ -5962,7 +5962,7 @@ new-github-issue-url@^0.1.2:
   resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.1.2.tgz#43f852cbf4f5eaa128e0850ea527d9c103fd3b1c"
   integrity sha512-FmF8JH2dGczrnY4cVKB7BjpaKFpySvZvPNZOhuMevY4+a1jSlI/me95rdulg9C5/74P/i02G+3WqpXN1Fhcoow==
 
-next@^7.0.0:
+next@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/next/-/next-7.0.2.tgz#5ff6b3f0e6cf03ce539d5779a55dc1f8fb1759d7"
   integrity sha512-DOPKKk+2rAEvXS/JMaZL5+jd2WUJI5BEv8xXiR4ijqIuvAL0dI/cT8H6bhFCqbYIgFNuefp+NSVh2kvxpELyeg==


### PR DESCRIPTION
Fix #477 

Apple broke the cursor hide/show API in high sierra, so we hide the option there to avoid confusion.