### PR TITLE
Add application menu

### DIFF
--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -132,7 +132,7 @@ const stopRecording = async () => {
   }
 
   track('editor/opened/recording');
-  openEditorWindow(filePath, recordedFps);
+  openEditorWindow(filePath, recordedFps, {isNewRecording: true});
 };
 
 module.exports = {

--- a/main/cropper.js
+++ b/main/cropper.js
@@ -14,7 +14,7 @@ let isCropperOpen = false;
 
 const closeAllCroppers = () => {
   const {screen} = electron;
-  
+
   isCropperOpen = false;
   screen.removeAllListeners('display-removed');
   screen.removeAllListeners('display-added');
@@ -23,7 +23,7 @@ const closeAllCroppers = () => {
     cropper.destroy();
     croppers.delete(id);
   }
-  
+
   if (notificationId !== null) {
     systemPreferences.unsubscribeWorkspaceNotification(notificationId);
     notificationId = null;

--- a/main/cropper.js
+++ b/main/cropper.js
@@ -10,6 +10,7 @@ const {BrowserWindow, systemPreferences} = electron;
 
 const croppers = new Map();
 let notificationId = null;
+let isCropperOpen = false;
 
 const closeAllCroppers = () => {
   const {screen} = electron;
@@ -19,6 +20,7 @@ const closeAllCroppers = () => {
     croppers.delete(id);
   }
 
+  isCropperOpen = false;
   screen.removeAllListeners('display-removed');
   screen.removeAllListeners('display-added');
   if (notificationId !== null) {
@@ -77,6 +79,7 @@ const openCropper = (display, activeDisplayId) => {
 
 const openCropperWindow = () => {
   closeAllCroppers();
+  isCropperOpen = true;
 
   const {screen} = electron;
   const displays = screen.getAllDisplays();
@@ -175,5 +178,6 @@ module.exports = {
   closeAllCroppers,
   selectApp,
   setRecordingCroppers,
-  disableCroppers
+  disableCroppers,
+  isCropperOpen: () => isCropperOpen
 };

--- a/main/editor.js
+++ b/main/editor.js
@@ -17,7 +17,7 @@ const MIN_VIDEO_WIDTH = 768;
 const MIN_VIDEO_HEIGHT = MIN_VIDEO_WIDTH * VIDEO_ASPECT;
 const MIN_WINDOW_HEIGHT = MIN_VIDEO_HEIGHT + OPTIONS_BAR_HEIGHT;
 
-const getEditorName = (filePath, isNewRecording) => isNewRecording ? `New Recording at ${moment().format('H.mm.ss')}` : path.basename(filePath);
+const getEditorName = (filePath, isNewRecording) => isNewRecording ? `New Recording ${moment().format('YYYY-MM-DD')} at ${moment().format('H.mm.ss')}` : path.basename(filePath);
 
 const openEditorWindow = async (filePath, recordFps, {isNewRecording} = {isNewRecording: false}) => {
   if (editors.has(filePath)) {

--- a/main/editor.js
+++ b/main/editor.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {BrowserWindow, app, dialog} = require('electron');
+const path = require('path');
 const ipc = require('electron-better-ipc');
 const {is} = require('electron-util');
 
@@ -50,6 +51,7 @@ const openEditorWindow = async (filePath, recordFps) => {
   const fps = recordFps || await getFps(filePath);
 
   editorWindow = new BrowserWindow({
+    title: path.basename(filePath),
     minWidth: MIN_VIDEO_WIDTH,
     minHeight: MIN_WINDOW_HEIGHT,
     width: MIN_VIDEO_WIDTH,

--- a/main/editor.js
+++ b/main/editor.js
@@ -4,6 +4,7 @@ const {BrowserWindow, dialog} = require('electron');
 const path = require('path');
 const ipc = require('electron-better-ipc');
 const {is} = require('electron-util');
+const moment = require('moment');
 
 const getFps = require('./utils/fps');
 const loadRoute = require('./utils/routes');
@@ -16,6 +17,8 @@ const MIN_VIDEO_WIDTH = 768;
 const MIN_VIDEO_HEIGHT = MIN_VIDEO_WIDTH * VIDEO_ASPECT;
 const MIN_WINDOW_HEIGHT = MIN_VIDEO_HEIGHT + OPTIONS_BAR_HEIGHT;
 
+const getEditorName = (filePath, isNewRecording) => isNewRecording ? `New Recording at ${moment().format('H.mm.ss')}` : path.basename(filePath);
+
 const openEditorWindow = async (filePath, recordFps, {isNewRecording} = {isNewRecording: false}) => {
   if (editors.has(filePath)) {
     editors.get(filePath).show();
@@ -25,7 +28,7 @@ const openEditorWindow = async (filePath, recordFps, {isNewRecording} = {isNewRe
   const fps = recordFps || await getFps(filePath);
 
   const editorWindow = new BrowserWindow({
-    title: path.basename(filePath),
+    title: getEditorName(filePath, isNewRecording),
     minWidth: MIN_VIDEO_WIDTH,
     minHeight: MIN_WINDOW_HEIGHT,
     width: MIN_VIDEO_WIDTH,

--- a/main/exports.js
+++ b/main/exports.js
@@ -1,20 +1,25 @@
 'use strict';
 
-const {BrowserWindow, app} = require('electron');
+const {BrowserWindow, ipcMain} = require('electron');
+const pEvent = require('p-event');
+
 const loadRoute = require('./utils/routes');
 
 let exportsWindow = null;
 
-const openExportsWindow = show => {
-  if (!exportsWindow) {
+const openExportsWindow = async () => {
+  if (exportsWindow) {
+    exportsWindow.focus();
+  } else {
     exportsWindow = new BrowserWindow({
+      title: 'Exports',
       width: 320,
       height: 360,
       resizable: false,
       maximizable: false,
       fullscreenable: false,
       titleBarStyle: 'hiddenInset',
-      show
+      show: false
     });
 
     const titlebarHeight = 37;
@@ -22,46 +27,20 @@ const openExportsWindow = show => {
 
     loadRoute(exportsWindow, 'exports');
 
-    exportsWindow.on('close', event => {
-      event.preventDefault();
-      exportsWindow.hide();
-    });
-
-    exportsWindow.on('closed', () => {
+    exportsWindow.on('close', () => {
       exportsWindow = null;
     });
-  }
-};
 
-const closeExportsWindow = () => {
-  if (exportsWindow) {
-    exportsWindow.close();
+    await pEvent(ipcMain, 'exports-ready');
+    exportsWindow.show();
   }
+
+  return exportsWindow;
 };
 
 const getExportsWindow = () => exportsWindow;
 
-const showExportsWindow = () => {
-  if (!exportsWindow) {
-    openExportsWindow(true);
-  }
-
-  if (exportsWindow.isVisible()) {
-    exportsWindow.focus();
-  } else {
-    exportsWindow.show();
-  }
-};
-
-app.on('before-quit', () => {
-  if (exportsWindow) {
-    exportsWindow.removeAllListeners('close');
-  }
-});
-
 module.exports = {
   openExportsWindow,
-  getExportsWindow,
-  closeExportsWindow,
-  showExportsWindow
+  getExportsWindow
 };

--- a/main/index.js
+++ b/main/index.js
@@ -11,7 +11,7 @@ const {initializeTray} = require('./tray');
 const plugins = require('./common/plugins');
 const {initializeAnalytics} = require('./common/analytics');
 const initializeExportList = require('./export-list');
-const {openCropperWindow} = require('./cropper');
+const {openCropperWindow, isCropperOpen} = require('./cropper');
 const {openEditorWindow} = require('./editor');
 const {track} = require('./common/analytics');
 const {initializeGlobalAccelerators} = require('./global-accelerators');
@@ -93,4 +93,8 @@ app.on('window-all-closed', event => {
   event.preventDefault();
 });
 
-app.on('browser-window-created', app.dock.show);
+app.on('browser-window-created', () => {
+  if (!isCropperOpen()) {
+    app.dock.show();
+  }
+});

--- a/main/index.js
+++ b/main/index.js
@@ -15,6 +15,7 @@ const {openCropperWindow} = require('./cropper');
 const {openEditorWindow} = require('./editor');
 const {track} = require('./common/analytics');
 const {initializeGlobalAccelerators} = require('./global-accelerators');
+const {setApplicationMenu} = require('./menus');
 
 require('./utils/sentry');
 
@@ -71,6 +72,7 @@ const checkForUpdates = () => {
   initializeTray();
   initializeExportList();
   initializeGlobalAccelerators();
+  setApplicationMenu();
 
   for (const file of filesToOpen) {
     track('editor/opened/startup');
@@ -86,4 +88,9 @@ const checkForUpdates = () => {
   checkForUpdates();
 })();
 
-app.on('window-all-closed', event => event.preventDefault());
+app.on('window-all-closed', event => {
+  app.dock.hide();
+  event.preventDefault();
+});
+
+app.on('browser-window-created', app.dock.show);

--- a/main/menus.js
+++ b/main/menus.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const os = require('os');
-const {Menu, app, dialog, BrowserWindow} = require('electron');
-const {openNewGitHubIssue} = require('electron-util');
+const {Menu, app, dialog} = require('electron');
+const {openNewGitHubIssue, appMenu} = require('electron-util');
 const {supportedVideoExtensions} = require('./common/constants');
 const {openPrefsWindow} = require('./preferences');
 const {openExportsWindow} = require('./exports');
@@ -36,32 +36,14 @@ Workaround:           A workaround for the issue if you've found on. (this will 
 <!-- If you have additional information, enter it below. -->
 `;
 
-const cogMenuTemplate = [{
-  label: `About ${app.getName()}`,
-  click: openAboutWindow
-}, {
-  type: 'separator'
-}, {
-  label: 'Send Feedback…',
-  click() {
-    openNewGitHubIssue({
-      user: 'wulkano',
-      repo: 'kap',
-      body: issueBody
-    });
-  }
-}, {
-  type: 'separator'
-}, {
+const openFileItem = {
   label: 'Open Video…',
   accelerator: 'Command+O',
   click: () => {
     closeAllCroppers();
 
     dialog.showOpenDialog({
-      filters: [
-        {name: 'Videos', extensions: supportedVideoExtensions}
-      ],
+      filters: [{name: 'Videos', extensions: supportedVideoExtensions}],
       properties: ['openFile']
     }, filePaths => {
       if (filePaths) {
@@ -71,152 +53,109 @@ const cogMenuTemplate = [{
       }
     });
   }
-}, {
-  label: 'Export History…',
+};
+
+const sendFeedbackItem = {
+  label: 'Send Feedback…',
+  click() {
+    openNewGitHubIssue({
+      user: 'wulkano',
+      repo: 'kap',
+      body: issueBody
+    });
+  }
+};
+
+const aboutItem = {
+  label: `About ${app.getName()}`,
+  click: openAboutWindow
+};
+
+const exportHistoryItem = {
+  label: 'Export History',
   click: openExportsWindow,
   enabled: false,
   id: 'exports'
-}, {
-  type: 'separator'
-}, {
+};
+
+const preferencesItem = {
   label: 'Preferences…',
   accelerator: 'Command+,',
   click: openPrefsWindow
-}, {
-  type: 'separator'
-}, {
-  role: 'quit',
-  accelerator: 'Command+Q'
-}];
+};
 
-const applicationMenuTemplate = [{
-  label: app.getName(),
-  submenu: [{
-    label: `About ${app.getName()}`,
-    click: openAboutWindow
-  }, {
+const cogMenuTemplate = [
+  aboutItem,
+  {
     type: 'separator'
-  }, {
-    label: 'Preferences…',
-    accelerator: 'Command+,',
-    click: openPrefsWindow
-  }, {
+  },
+  sendFeedbackItem,
+  {
     type: 'separator'
-  }, {
-    label: 'Services',
-    role: 'services',
-    submenu: []
-  }, {
+  },
+  openFileItem,
+  exportHistoryItem,
+  {
     type: 'separator'
-  }, {
-    label: 'Export History…',
-    click: openExportsWindow,
-    enabled: false,
-    id: 'exports'
-  }, {
+  },
+  preferencesItem,
+  {
     type: 'separator'
-  }, {
-    label: `Hide ${app.getName()}`,
-    accelerator: 'Command+H',
-    role: 'hide'
-  }, {
-    label: 'Hide Others',
-    accelerator: 'Command+Shift+H',
-    role: 'hideothers'
-  }, {
-    label: 'Show All',
-    role: 'unhide'
-  }, {
-    type: 'separator'
-  }, {
+  },
+  {
     role: 'quit',
     accelerator: 'Command+Q'
-  }]
-}, {
-  label: 'File',
-  submenu: [{
-    label: 'Open Video…',
-    accelerator: 'Command+O',
-    click: () => {
-      closeAllCroppers();
+  }
+];
 
-      dialog.showOpenDialog({
-        filters: [
-          {name: 'Videos', extensions: supportedVideoExtensions}
-        ],
-        properties: ['openFile']
-      }, filePaths => {
-        if (filePaths) {
-          for (const file of filePaths) {
-            openEditorWindow(file);
-          }
-        }
-      });
-    }
-  }, {
-    type: 'separator'
-  }, {
-    label: 'Close',
-    accelerator: 'Command+W',
-    click: () => {
-      BrowserWindow.getFocusedWindow().close();
-    }
-  }]
-}, {
-  label: 'Edit',
-  submenu: [{
-    label: 'Undo',
-    accelerator: 'CmdOrCtrl+Z',
-    role: 'undo'
-  }, {
-    label: 'Redo',
-    accelerator: 'Shift+CmdOrCtrl+Z',
-    role: 'redo'
-  }, {
-    type: 'separator'
-  }, {
-    label: 'Cut',
-    accelerator: 'CmdOrCtrl+X',
-    role: 'cut'
-  }, {
-    label: 'Copy',
-    accelerator: 'CmdOrCtrl+C',
-    role: 'copy'
-  }, {
-    label: 'Paste',
-    accelerator: 'CmdOrCtrl+V',
-    role: 'paste'
-  }, {
-    label: 'Select All',
-    accelerator: 'CmdOrCtrl+A',
-    role: 'selectall'
-  }]
-}, {
-  label: 'Window',
-  role: 'window',
-  submenu: [{
-    label: 'Minimize',
-    accelerator: 'CmdOrCtrl+M',
-    role: 'minimize'
-  }, {
-    label: 'Close',
-    accelerator: 'CmdOrCtrl+W',
-    role: 'close'
-  }]
-}, {
-  label: 'Help',
-  role: 'help',
-  submenu: [{
-    label: 'Send Feedback…',
-    click() {
-      openNewGitHubIssue({
-        user: 'wulkano',
-        repo: 'kap',
-        body: issueBody
-      });
-    }
-  }]
-}];
+const appMenuItem = appMenu([preferencesItem]);
+
+appMenuItem.submenu[0] = aboutItem;
+
+const applicationMenuTemplate = [
+  appMenuItem,
+  {
+    label: 'File',
+    submenu: [
+      openFileItem,
+      {
+        type: 'separator'
+      },
+      {
+        role: 'close'
+      }
+    ]
+  },
+  {
+    role: 'editMenu'
+  },
+  {
+    role: 'window',
+    submenu: [
+      {
+        role: 'minimize'
+      },
+      {
+        role: 'zoom'
+      },
+      {
+        type: 'separator'
+      },
+      exportHistoryItem,
+      {
+        type: 'separator'
+      },
+      {
+        role: 'front'
+      }
+    ]
+  },
+  {
+    label: 'Help',
+    role: 'help',
+    submenu: [sendFeedbackItem]
+  }
+];
 
 const cogMenu = Menu.buildFromTemplate(cogMenuTemplate);
 const cogExportsItem = cogMenu.getMenuItemById('exports');

--- a/main/preferences.js
+++ b/main/preferences.js
@@ -19,6 +19,7 @@ const openPrefsWindow = async () => {
   }
 
   prefsWindow = new BrowserWindow({
+    title: 'Preferences',
     width: 480,
     height: 480,
     resizable: false,

--- a/renderer/components/exports/index.js
+++ b/renderer/components/exports/index.js
@@ -1,3 +1,4 @@
+import electron from 'electron';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -5,6 +6,12 @@ import {connect, ExportsContainer} from '../../containers';
 import Export from './export';
 
 class Exports extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isMounted && this.props.isMounted) {
+      electron.ipcRenderer.send('exports-ready');
+    }
+  }
+
   render() {
     const {exports, cancel, openInEditor} = this.props;
 
@@ -31,11 +38,12 @@ class Exports extends React.Component {
 Exports.propTypes = {
   exports: PropTypes.arrayOf(PropTypes.object),
   cancel: PropTypes.func,
-  openInEditor: PropTypes.func
+  openInEditor: PropTypes.func,
+  isMounted: PropTypes.bool
 };
 
 export default connect(
   [ExportsContainer],
-  ({exports}) => ({exports}),
+  ({exports, isMounted}) => ({exports, isMounted}),
   ({cancel, openInEditor}) => ({cancel, openInEditor})
 )(Exports);

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -25,7 +25,10 @@ const Key = ({children}) => (
 );
 
 Key.propTypes = {
-  children: PropTypes.element
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired
 };
 
 const noop = () => {};

--- a/renderer/containers/exports.js
+++ b/renderer/containers/exports.js
@@ -11,7 +11,10 @@ export default class ExportsContainer extends Container {
     ipc = require('electron-better-ipc');
     const exports = await ipc.callMain('get-exports');
 
-    this.setState({exports: exports.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))});
+    this.setState({
+      exports: exports.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)),
+      isMounted: true
+    });
 
     ipc.answerMain('update-export', this.update);
   }


### PR DESCRIPTION
Fixes #549 
Fixes #552 

Adds application menu and dock along with window titles. Enables all the common shortcuts (Copy, Cut, Paste etc)

Had the change the exports window implementation. Used to always be open and just shown/hidden. Switched to actually opening/closing it so I can show/hide the dock when there are no windows. Added a 'exports-ready' event to show the window when the rendering has finished

![kapture 2019-01-29 at 10 50 19](https://user-images.githubusercontent.com/8822835/51920588-b6881300-23b3-11e9-84c1-17fd393a2834.gif)
