### PR TITLE
Editor traffic lights

### DIFF
--- a/renderer/components/traffic-lights.js
+++ b/renderer/components/traffic-lights.js
@@ -15,8 +15,7 @@ export default class TrafficLights extends React.Component {
     electron.remote.systemPreferences.unsubscribeNotification(this.tintSubscription);
   }
 
-  getTintColor = () =>
-    electron.remote.systemPreferences.getUserDefault('AppleAquaColorVariant', 'string') === '1' ? 'blue' : 'graphite';
+  getTintColor = () => electron.remote.systemPreferences.getUserDefault('AppleAquaColorVariant', 'string') === '6' ? 'graphite' : 'blue';
 
   onTintChange = () => {
     this.setState({tint: this.getTintColor()});


### PR DESCRIPTION
So, for some reason the traffic lights of my editor windows started showing up as gray. I had never switched my settings to `graphite`. After switching it and switching it back to `blue` it worked. So I'm guessing if you have never touched the setting its value is not set but the system uses blue by default.

Switched the implementation to only use `graphite` if it's explicitly set to that, therefore defaulting to `blue` otherwise.