### PR TITLE
Fix cropper error

### DIFF
--- a/main/cropper.js
+++ b/main/cropper.js
@@ -103,11 +103,13 @@ const openCropperWindow = () => {
 
     cropper.removeAllListeners('closed');
     cropper.destroy();
-    delete croppers[id];
+    croppers.delete(id);
 
     if (wasFocused) {
       const activeDisplayId = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).id;
-      croppers.get(activeDisplayId).focus();
+      if (croppers.has(activeDisplayId)) {
+        croppers.get(activeDisplayId).focus();
+      }
     }
   });
 

--- a/main/cropper.js
+++ b/main/cropper.js
@@ -14,13 +14,14 @@ let notificationId = null;
 const closeAllCroppers = () => {
   const {screen} = electron;
 
+  screen.removeAllListeners('display-removed');
+  screen.removeAllListeners('display-added');
+
   for (const [id, cropper] of croppers) {
     cropper.destroy();
     croppers.delete(id);
   }
 
-  screen.removeAllListeners('display-removed');
-  screen.removeAllListeners('display-added');
   if (notificationId !== null) {
     systemPreferences.unsubscribeWorkspaceNotification(notificationId);
     notificationId = null;


### PR DESCRIPTION
Fixes #611 

Sentry issue: [KAP-3G4](https://sentry.io/wulkano-l0/kap/issues/826902789/?referrer=github_plugin)

Not sure how this code was ever reached having only one monitor, or why the active display would not have a corresponding cropper. I checked that the event handler is correctly cleaned up when the croppers close, so the croppers should all be there when that event fires. I moved the cleanup before the croppers are actually destroyed to avoid any race conditions, and added and if guard to make sure that error is not fired under any circumstance