### PR TITLE
Fix queued exports getting stuck

### DIFF
--- a/main/export-list.js
+++ b/main/export-list.js
@@ -89,8 +89,6 @@ class ExportList {
     if (this.currentExport && this.currentExport.createdAt === createdAt) {
       track('export/canceled/current');
       this.currentExport.cancel();
-      delete this.currentExport;
-      this._startNext();
     } else {
       const exportToCancel = this.exports.find(exp => exp.createdAt === createdAt);
       if (exportToCancel) {


### PR DESCRIPTION
Fixes #590 

At some point I added the mute functionality, but for the two formats that I added it (mp4, webm), that made the function return a new promise which was not cancelable. Therefore, when trying to cancel, it would crash and the queue would stop, therefore never picking up subsequent jobs. 

Turning those two into `PCancelable` solved the error.

This also goes to show that #393 is needed. I might start working on some tests later this week