### PR TITLE
Use input type password

### DIFF
--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -9,11 +9,11 @@ import {OpenOnGithubIcon, OpenConfigIcon} from '../../vectors';
 const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
   if (type === 'string') {
     const className = hasErrors ? 'has-errors' : '';
-    const password = name.match("password") ? "password" : "text";
+    const type = name.match('password') ? 'password' : 'text';
 
     return (
       <div>
-        <input type={password} className={className} value={value || ''} onChange={e => onChange(name, e.target.value || undefined)}/>
+        <input type={type} className={className} value={value || ''} onChange={e => onChange(name, e.target.value || undefined)}/>
         <style jsx>{`
           input {
             outline: none;

--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -9,9 +9,11 @@ import {OpenOnGithubIcon, OpenConfigIcon} from '../../vectors';
 const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
   if (type === 'string') {
     const className = hasErrors ? 'has-errors' : '';
+    const password = name.match("password") ? "password" : "text";
+
     return (
       <div>
-        <input className={className} value={value || ''} onChange={e => onChange(name, e.target.value || undefined)}/>
+        <input type={password} className={className} value={value || ''} onChange={e => onChange(name, e.target.value || undefined)}/>
         <style jsx>{`
           input {
             outline: none;


### PR DESCRIPTION
Use input type password for config fields in plugins containing "password" in name.

Example Plugin config

```
...
password: {
      title: 'Password',
      type: 'string',
      required: true
},
...
```
Result:

<img width="320" alt="bildschirmfoto 2019-02-02 um 19 12 54" src="https://user-images.githubusercontent.com/4623070/52167649-942d2700-271e-11e9-9ddb-6babdd446241.png">
