### PR TITLE
Fix editor dropdown arrow focused state

### DIFF
--- a/renderer/components/editor/options/select.js
+++ b/renderer/components/editor/options/select.js
@@ -63,6 +63,7 @@ class Select extends React.Component {
             justify-content: center;
             align-items: center;
             width: 18px;
+            pointer-events: none;
           }
         `}</style>
       </div>

--- a/renderer/vectors/svg.js
+++ b/renderer/vectors/svg.js
@@ -69,9 +69,6 @@ class Svg extends React.Component {
               position: relative;
               width: ${size};
               height: ${size};
-            }
-
-            div:focus {
               outline: none;
             }
 


### PR DESCRIPTION
Fixes the wrong focused state of the dropdown arrows in the editor that was introduced by the PR that added tab support to the cropper

<img width="162" alt="screen shot 2019-02-15 at 11 09 15 am" src="https://user-images.githubusercontent.com/8822835/52870282-7c3da600-3115-11e9-8847-b3cc17ee4ec7.png">
