### PR TITLE
Stop recording when the cropper accelerator is used

### DIFF
--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -7,8 +7,9 @@ const createAperture = require('aperture');
 
 const {openEditorWindow} = require('../editor');
 const {closePrefsWindow} = require('../preferences');
-const {setRecordingTray, disableTray} = require('../tray');
+const {setRecordingTray, disableTray, resetTray} = require('../tray');
 const {disableCroppers, setRecordingCroppers, closeAllCroppers} = require('../cropper');
+const {setCropperShortcutAction} = require('../global-accelerators');
 const settings = require('./settings');
 const {track} = require('./analytics');
 
@@ -96,6 +97,7 @@ const startRecording = async options => {
     console.log(`Started recording after ${startTime}s`);
     setRecordingCroppers();
     setRecordingTray(stopRecording);
+    setCropperShortcutAction(stopRecording);
     past = Date.now();
   } catch (error) {
     track('recording/stopped/error');
@@ -114,6 +116,8 @@ const stopRecording = async () => {
   console.log(`Stopped recording after ${(Date.now() - past) / 1000}s`);
   track('recording/stopped');
   closeAllCroppers();
+  setCropperShortcutAction();
+  resetTray();
 
   const filePath = await aperture.stopRecording();
 

--- a/main/cropper.js
+++ b/main/cropper.js
@@ -79,6 +79,10 @@ const openCropper = (display, activeDisplayId) => {
 };
 
 const openCropperWindow = () => {
+  if (isCropperOpen) {
+    return;
+  }
+
   closeAllCroppers();
   isCropperOpen = true;
 

--- a/main/global-accelerators.js
+++ b/main/global-accelerators.js
@@ -6,8 +6,22 @@ const store = require('./common/settings');
 const {openCropperWindow} = require('./cropper');
 
 // All settings that should be loaded and handled as global accelerators
-const handlers = {
-  cropperShortcut: openCropperWindow
+const handlers = new Map([
+  ['cropperShortcut', openCropperWindow]
+]);
+
+// If no action is passed, it resets
+const setCropperShortcutAction = (action = openCropperWindow) => {
+  if (store.get('recordKeyboardShortcut') && store.has('cropperShortcut')) {
+    handlers.set('cropperShortcut', action);
+
+    const shortcut = shortcutToAccelerator(store.get('cropperShortcut'));
+    if (globalShortcut.isRegistered(shortcut)) {
+      globalShortcut.unregister(shortcut);
+    }
+
+    globalShortcut.register(shortcut, action);
+  }
 };
 
 const registerShortcut = (shortcut, action) => {
@@ -21,7 +35,7 @@ const registerShortcut = (shortcut, action) => {
 
 const registrerFromStore = () => {
   if (store.get('recordKeyboardShortcut')) {
-    for (const [setting, action] of Object.entries(handlers)) {
+    for (const [setting, action] of handlers.entries()) {
       const shortcut = store.get(setting);
       if (shortcut) {
         registerShortcut(shortcut, action);
@@ -49,7 +63,7 @@ const initializeGlobalAccelerators = () => {
     store.set(setting, shortcut);
 
     if (shortcut) {
-      registerShortcut(shortcut, handlers[setting]);
+      registerShortcut(shortcut, handlers.get(setting));
     }
   });
 
@@ -66,5 +80,6 @@ const initializeGlobalAccelerators = () => {
 };
 
 module.exports = {
-  initializeGlobalAccelerators
+  initializeGlobalAccelerators,
+  setCropperShortcutAction
 };

--- a/main/tray.js
+++ b/main/tray.js
@@ -38,15 +38,15 @@ const disableTray = () => {
   tray.removeListener('right-click', openContextMenu);
 };
 
+const resetTray = () => {
+  tray.setImage(path.join(__dirname, '..', 'static', 'menubarDefaultTemplate.png'));
+  tray.on('click', openCropperWindow);
+  tray.on('right-click', openContextMenu);
+};
+
 const setRecordingTray = stopRecording => {
   animateIcon();
-
-  tray.once('click', () => {
-    stopRecording();
-    tray.setImage(path.join(__dirname, '..', 'static', 'menubarDefaultTemplate.png'));
-    tray.on('click', openCropperWindow);
-    tray.on('right-click', openContextMenu);
-  });
+  tray.once('click', stopRecording);
 };
 
 const animateIcon = () => new Promise(resolve => {
@@ -73,5 +73,6 @@ const animateIcon = () => new Promise(resolve => {
 module.exports = {
   initializeTray,
   disableTray,
-  setRecordingTray
+  setRecordingTray,
+  resetTray
 };


### PR DESCRIPTION
Fixes #625 

This currently uses the shortcut used to open the Cropper. We don't have a global shortcut to start recording while you are in the cropper view. So, this shortcut opens the cropper if you are not recording, or stops the recording if you are.