### PR TITLE
Fix Kap preventing sleep

### DIFF
--- a/main/editor.js
+++ b/main/editor.js
@@ -72,8 +72,14 @@ const openEditorWindow = async (filePath, {recordedFps, isNewRecording, original
     });
   }
 
-  editorWindow.on('blur', () => editorEmitter.emit('blur'));
-  editorWindow.on('focus', () => editorEmitter.emit('focus'));
+  editorWindow.on('blur', () => {
+    editorEmitter.emit('blur');
+    ipc.callRenderer(editorWindow, 'blur');
+  });
+  editorWindow.on('focus', () => {
+    editorEmitter.emit('focus');
+    ipc.callRenderer(editorWindow, 'focus');
+  });
 
   editorWindow.webContents.on('did-finish-load', async () => {
     ipc.callRenderer(editorWindow, 'export-options', exportOptions);

--- a/renderer/pages/editor.js
+++ b/renderer/pages/editor.js
@@ -24,8 +24,9 @@ export default class EditorPage extends React.Component {
     });
 
     ipc.answerMain('export-options', editorContainer.setOptions);
-
     ipc.answerMain('save-original', editorContainer.saveOriginal);
+    ipc.answerMain('blur', videoContainer.pause);
+    ipc.answerMain('focus', videoContainer.play);
   }
 
   render() {

--- a/renderer/pages/editor.js
+++ b/renderer/pages/editor.js
@@ -13,6 +13,8 @@ videoContainer.setEditorContainer(editorContainer);
 editorContainer.setVideoContainer(videoContainer);
 
 export default class EditorPage extends React.Component {
+  wasPaused = false;
+
   componentDidMount() {
     const ipc = require('electron-better-ipc');
 
@@ -25,8 +27,16 @@ export default class EditorPage extends React.Component {
 
     ipc.answerMain('export-options', editorContainer.setOptions);
     ipc.answerMain('save-original', editorContainer.saveOriginal);
-    ipc.answerMain('blur', videoContainer.pause);
-    ipc.answerMain('focus', videoContainer.play);
+
+    ipc.answerMain('blur', () => {
+      this.wasPaused = videoContainer.state.isPaused;
+      videoContainer.pause();
+    });
+    ipc.answerMain('focus', () => {
+      if (!this.wasPaused) {
+        videoContainer.play();
+      }
+    });
   }
 
   render() {

--- a/renderer/vectors/svg.js
+++ b/renderer/vectors/svg.js
@@ -92,7 +92,9 @@ class Svg extends React.Component {
               filter: drop-shadow(0 1px 2px rgba(0,0,0,.1));
             }
 
-            .active, .active:hover {
+            .active,
+            .active:hover,
+            div:focus svg {
               fill: ${activeFill};
             }
         `}</style>


### PR DESCRIPTION
When an editor was open, Kap would prevent the computer from going sleep. This was caused by chrome's functionality of preventing sleep when there's media playing on the page. Until a better solution is found, we decided to at least pause the editor window when it is blurred, and resume when focused.

This indeed removes Kap from the list of Apps that prevent sleep a couple of seconds after blurring. The issue, of course, will remain if you keep the editor focused.

Questions:
- While doing this, I was also wondering if it would be worth utilizing that functionality and preventing the computer from sleeping while aperture is recording. I think I've heard of a couple of issues of putting the computer to sleep while recording, but I'm not 100% sure.