### PR TITLE
Work around the "Save" dialog bug in Electron

### DIFF
--- a/main/editor.js
+++ b/main/editor.js
@@ -94,7 +94,18 @@ const setOptions = options => {
 
 const getEditors = () => editors.values();
 
-ipc.answerRenderer('save-original', ({inputPath, outputPath}) => promisify(fs.copyFile)(inputPath, outputPath, fs.constants.COPYFILE_FICLONE));
+ipc.answerRenderer('save-original', async ({inputPath}) => {
+  const now = moment();
+
+  try {
+    await promisify(dialog.showSaveDialog)(BrowserWindow.getFocusedWindow(), {
+      defaultPath: `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.mp4`
+    });
+    // eslint-disable-next-line unicorn/catch-error-name
+  } catch (path) {
+    return promisify(fs.copyFile)(inputPath, path, fs.constants.COPYFILE_FICLONE);
+  }
+});
 
 module.exports = {
   openEditorWindow,

--- a/main/editor.js
+++ b/main/editor.js
@@ -21,6 +21,7 @@ const MIN_VIDEO_HEIGHT = MIN_VIDEO_WIDTH * VIDEO_ASPECT;
 const MIN_WINDOW_HEIGHT = MIN_VIDEO_HEIGHT + OPTIONS_BAR_HEIGHT;
 const editorEmitter = new EventEmitter();
 
+const showSaveDialog = pify(dialog.showSaveDialog, {errorFirst: false});
 const getEditorName = (filePath, isNewRecording) => isNewRecording ? `New Recording ${moment().format('YYYY-MM-DD')} at ${moment().format('H.mm.ss')}` : path.basename(filePath);
 
 const openEditorWindow = async (filePath, {recordedFps, isNewRecording, originalFilePath} = {}) => {
@@ -97,12 +98,12 @@ const getEditors = () => editors.values();
 ipc.answerRenderer('save-original', async ({inputPath}) => {
   const now = moment();
 
-  const path = await pify(dialog.showSaveDialog, {errorFirst: false})(BrowserWindow.getFocusedWindow(), {
+  const path = await showSaveDialog(BrowserWindow.getFocusedWindow(), {
     defaultPath: `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.mp4`
   });
 
   if (path) {
-    return pify(fs.copyFile)(inputPath, path, fs.constants.COPYFILE_FICLONE);
+    await pify(fs.copyFile)(inputPath, path, fs.constants.COPYFILE_FICLONE);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "npm": "^6.8.0",
     "p-cancelable": "^1.0.0",
     "p-event": "^2.3.1",
+    "pify": "^4.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -1,6 +1,4 @@
-import electron from 'electron';
 import {Container} from 'unstated';
-import moment from 'moment';
 import {shake} from '../utils/inputs';
 
 const isMuted = format => ['gif', 'apng'].includes(format);
@@ -100,20 +98,8 @@ export default class EditorContainer extends Container {
 
   saveOriginal = () => {
     const {filePath, originalFilePath} = this.state;
-    const {remote} = electron;
-
-    const now = moment();
-
-    const path = remote.dialog.showSaveDialog(remote.BrowserWindow.getFocusedWindow(), {
-      defaultPath: `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.mp4`
-    });
-
     const ipc = require('electron-better-ipc');
-
-    ipc.callMain('save-original', {
-      inputPath: originalFilePath || filePath,
-      outputPath: path
-    });
+    ipc.callMain('save-original', {inputPath: originalFilePath || filePath});
   }
 
   selectFormat = format => {
@@ -170,19 +156,11 @@ export default class EditorContainer extends Container {
   getSnapshot = () => {
     const time = this.videoContainer.state.currentTime;
     const {filePath} = this.state;
-    const {remote} = electron;
-
-    const now = moment();
-
-    const path = remote.dialog.showSaveDialog(remote.BrowserWindow.getFocusedWindow(), {
-      defaultPath: `Snapshot ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}.jpg`
-    });
 
     const ipc = require('electron-better-ipc');
 
     ipc.callMain('export-snapshot', {
       inputPath: filePath,
-      outputPath: path,
       time
     });
   }


### PR DESCRIPTION
(Hopefully) Fixes #368 

Tested locally on all 3 places we use a save dialog, and it's working fine

Used the workaround mentioned here: https://github.com/wulkano/kap/issues/368#issuecomment-473526414

`promisify` epxects an error-first callback, while electron's `showSaveDialog` calls it just with the file path or `undefined` if the user cancels. I used a catch block to get the file path, not sure if there's a better way, or if I should just write a small utility to implement `promisify` for this specific use-case