### PR TITLE
Fix incorrect filename being displayed after export

### DIFF
--- a/main/export.js
+++ b/main/export.js
@@ -38,7 +38,7 @@ class Export {
 
   get data() {
     return {
-      defaultFileName: this.defaultFileName,
+      defaultFileName: this.defaultFileName && (this.isDefault ? this.context.targetFilePath.replace(/^.*[\\\/]/, '') : this.defaultFileName),
       text: this.text,
       status: this.status,
       percentage: this.percentage,

--- a/main/export.js
+++ b/main/export.js
@@ -7,6 +7,7 @@ const {track} = require('./common/analytics');
 const {convertTo} = require('./convert');
 const ShareServiceContext = require('./share-service-context');
 const Plugin = require('./plugin');
+const path = require('path');
 
 class Export {
   constructor(options) {
@@ -38,7 +39,7 @@ class Export {
 
   get data() {
     return {
-      defaultFileName: this.defaultFileName && (this.isDefault ? this.context.targetFilePath.replace(/^.*[\\/]/, '') : this.defaultFileName),
+      defaultFileName: this.defaultFileName && (this.isDefault ? path.basename(this.context.targetFilePath) : this.defaultFileName),
       text: this.text,
       status: this.status,
       percentage: this.percentage,

--- a/main/export.js
+++ b/main/export.js
@@ -38,7 +38,7 @@ class Export {
 
   get data() {
     return {
-      defaultFileName: this.defaultFileName && (this.isDefault ? this.context.targetFilePath.replace(/^.*[\\\/]/, '') : this.defaultFileName),
+      defaultFileName: this.defaultFileName && (this.isDefault ? this.context.targetFilePath.replace(/^.*[\\/]/, '') : this.defaultFileName),
       text: this.text,
       status: this.status,
       percentage: this.percentage,

--- a/main/export.js
+++ b/main/export.js
@@ -39,7 +39,7 @@ class Export {
 
   get data() {
     return {
-      defaultFileName: this.defaultFileName && (this.isDefault ? path.basename(this.context.targetFilePath) : this.defaultFileName),
+      defaultFileName: this.isDefault ? path.basename(this.context.targetFilePath) : this.defaultFileName,
       text: this.text,
       status: this.status,
       percentage: this.percentage,

--- a/main/export.js
+++ b/main/export.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const PCancelable = require('p-cancelable');
 const moment = require('moment');
 
@@ -7,7 +8,6 @@ const {track} = require('./common/analytics');
 const {convertTo} = require('./convert');
 const ShareServiceContext = require('./share-service-context');
 const Plugin = require('./plugin');
-const path = require('path');
 
 class Export {
   constructor(options) {


### PR DESCRIPTION
When using the save to file service, the filename is placed in the context target path. Using that to display under export list - rather than using the generated default one.

Fixes #651