### PR TITLE
Work around a timing issue in the export window

### DIFF
--- a/main/export-list.js
+++ b/main/export-list.js
@@ -251,6 +251,7 @@ const callExportsWindow = (channel, data) => {
   const exportsWindow = getExportsWindow();
 
   if (exportsWindow) {
+    // TODO(karaggeorge): Investigate why `ipc.callRenderer(exportsWindow, channel, data);` is not working here.
     exportsWindow.webContents.send(channel, data);
   }
 };

--- a/main/export-list.js
+++ b/main/export-list.js
@@ -251,7 +251,7 @@ const callExportsWindow = (channel, data) => {
   const exportsWindow = getExportsWindow();
 
   if (exportsWindow) {
-    ipc.callRenderer(exportsWindow, channel, data);
+    exportsWindow.webContents.send(channel, data);
   }
 };
 

--- a/renderer/containers/exports.js
+++ b/renderer/containers/exports.js
@@ -16,7 +16,8 @@ export default class ExportsContainer extends Container {
       isMounted: true
     });
 
-    ipc.answerMain('update-export', this.update);
+    const {ipcRenderer} = require('electron');
+    ipcRenderer.on('update-export', (_, updates) => this.update(updates));
   }
 
   update = updates => {


### PR DESCRIPTION
After a decent amount of debugging and `console.log`ing I still don't know why that broke. Everything was working fine, and there was no timing issue, but the event just wasn't getting received in the renderer. 

I switched to use electron's native ipc and it works, so we can do a beta release, but I'll look into it more