### PR TITLE
Fix editor controls

### DIFF
--- a/renderer/components/editor/video.js
+++ b/renderer/components/editor/video.js
@@ -58,6 +58,7 @@ class Video extends React.Component {
           video {
             width: 100%;
             height: 100%;
+            max-height: calc(100vh - 48px);
           }
 
           .container {

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -41,7 +41,10 @@ export default class EditorContainer extends Container {
 
       if (name === 'width') {
         const min = Math.max(1, Math.ceil(ratio));
-        if (val < min) {
+
+        if (ignoreEmpty) {
+          updates.width = val;
+        } else if (val < min) {
           shake(currentTarget, {className: 'shake-left'});
           updates.width = min;
         } else if (val > original.width) {
@@ -54,7 +57,10 @@ export default class EditorContainer extends Container {
         updates.height = Math.round(updates.width / ratio);
       } else {
         const min = Math.max(1, Math.ceil(1 / ratio));
-        if (val < min) {
+
+        if (ignoreEmpty) {
+          updates.height = val;
+        } else if (val < min) {
           shake(currentTarget, {className: 'shake-right'});
           updates.height = min;
         } else if (val > original.height) {


### PR DESCRIPTION
Fixes #674 (again)

We fixed this in the past, but it sneaked in again as part of #587, which changed a lot of things around inputs

This PR also fixes a weird UI error that just started happening (but happened consistently) where if you recorded at a certain aspect ratio, the video preview in the editor would push the controls out of the window