### PR TITLE
Fix progress calculation and add time estimate for conversions

### DIFF
--- a/main/convert.js
+++ b/main/convert.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const execa = require('execa');
 const moment = require('moment');
+const prettyMs = require('pretty-ms');
 const tmp = require('tmp');
 const ffmpeg = require('@ffmpeg-installer/ffmpeg');
 const util = require('electron-util');
@@ -13,8 +14,8 @@ const tempy = require('tempy');
 const {track} = require('./common/analytics');
 
 const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
-const durationRegex = /Duration: (\d\d:\d\d:\d\d.\d\d)/gm;
-const frameRegex = /frame=\s+(\d+)/gm;
+const timeRegex = /time=\s*(\d\d:\d\d:\d\d.\d\d)/gm;
+const speedRegex = /speed=\s*(-?\d+(,\d+)*(\.\d+(e\d+)?)?)/gm;
 
 // https://trac.ffmpeg.org/ticket/309
 const makeEven = n => 2 * Math.round(n / 2);
@@ -24,7 +25,8 @@ const convert = (outputPath, opts, args) => {
 
   return new PCancelable((resolve, reject, onCancel) => {
     const converter = execa(ffmpegPath, args);
-    let amountOfFrames;
+    const durationMs = moment.duration(opts.endTime - opts.startTime, 'seconds').asMilliseconds();
+    let speed;
 
     onCancel(() => {
       track('file/export/convert/canceled');
@@ -37,14 +39,26 @@ const convert = (outputPath, opts, args) => {
       stderr += data;
 
       data = data.trim();
-      const matchesDuration = durationRegex.exec(data);
-      const matchesFrame = frameRegex.exec(data);
 
-      if (matchesDuration) {
-        amountOfFrames = Math.ceil(moment.duration(matchesDuration[1]).asSeconds() * 30);
-      } else if (matchesFrame) {
-        const currentFrame = matchesFrame[1];
-        opts.onProgress(currentFrame / amountOfFrames);
+      const processingSpeed = speedRegex.exec(data);
+
+      if (processingSpeed) {
+        speed = parseFloat(processingSpeed[1]);
+      }
+
+      const timeProccessed = timeRegex.exec(data);
+
+      if (timeProccessed) {
+        const processedMs = moment.duration(timeProccessed[1]).asMilliseconds();
+        const progress = processedMs / durationMs;
+
+        // Wait 2 second in the conversion for the speed to be stable
+        if (processedMs > 2 * 1000) {
+          const msRemaining = (durationMs - processedMs) / speed;
+          opts.onProgress(progress, prettyMs(Math.max(msRemaining, 1000), {compact: true}).substr(1));
+        } else {
+          opts.onProgress(progress);
+        }
       }
     });
 

--- a/main/export.js
+++ b/main/export.js
@@ -44,7 +44,7 @@ class Export {
       defaultFileName: this.isDefault ? path.basename(this.context.targetFilePath) : this.defaultFileName,
       text: this.text,
       status: this.status,
-      percentage: this.percentage,
+      percentage: this.percentage || 0,
       image: this.image,
       createdAt: this.createdAt,
       filePath: this.filePath && (this.isDefault ? this.context.targetFilePath : this.filePath),
@@ -113,7 +113,7 @@ class Export {
         ...this.exportOptions,
         defaultFileName: fileType ? `${path.parse(this.defaultFileName).name}.${fileType}` : this.defaultFileName,
         inputPath: this.inputPath,
-        onProgress: percentage => this.setProgress('Converting…', percentage)
+        onProgress: (percentage, estimate) => this.setProgress(estimate ? `Converting (${estimate} remaining)` : 'Converting…', percentage)
       },
       fileType || this.format
     );

--- a/main/export.js
+++ b/main/export.js
@@ -113,7 +113,7 @@ class Export {
         ...this.exportOptions,
         defaultFileName: fileType ? `${path.parse(this.defaultFileName).name}.${fileType}` : this.defaultFileName,
         inputPath: this.inputPath,
-        onProgress: (percentage, estimate) => this.setProgress(estimate ? `Converting (${estimate} remaining)` : 'Converting…', percentage)
+        onProgress: (percentage, estimate) => this.setProgress(estimate ? `Converting — ${estimate} remaining` : 'Converting…', percentage)
       },
       fileType || this.format
     );

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "package-json": "^6.5.0",
     "pify": "^4.0.1",
     "plist": "^3.0.1",
+    "pretty-ms": "^5.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6366,6 +6366,11 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse5-htmlparser2-tree-adapter@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.0.tgz#a8244ee12bbd6b8937ad2a16ea43fe348aebcc86"
@@ -6588,6 +6593,13 @@ pretty-bytes@^1.0.2:
   dependencies:
     get-stdin "^4.0.1"
     meow "^3.1.0"
+
+pretty-ms@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-5.0.0.tgz#6133a8f55804b208e4728f6aa7bf01085e951e24"
+  integrity sha512-94VRYjL9k33RzfKiGokPBPpsmloBYSf5Ri+Pq19zlsEcUKFob+admeXr5eFDRuPjFmEOcjJvPGdillYOJyvZ7Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 private@^0.1.6:
   version "0.1.8"


### PR DESCRIPTION
Progress calculation was done based on frames completed using an arbitrary fps of 30 and the length of the total video instead of just the trimmed part. That led to sometimes getting a slow progress that would end super fast, or a progress that would go above 100%. 

Refactored the progress to work off of length of video completed vs total length and added time remaining estimation based on that length and the converting speed, both of which are available in `ffmpeg`'s output