### PR TITLE
Window dark mode background styles and cropper bug fix

### DIFF
--- a/main/cropper.js
+++ b/main/cropper.js
@@ -6,6 +6,7 @@ const delay = require('delay');
 const settings = require('./common/settings');
 const {hasMicrophoneAccess, ensureMicrophonePermissions, openSystemPreferences} = require('./common/system-permissions');
 const loadRoute = require('./utils/routes');
+const {checkForAnyBlockingEditors} = require('./editor');
 
 const {BrowserWindow, systemPreferences, dialog} = electron;
 
@@ -82,6 +83,9 @@ const openCropper = (display, activeDisplayId) => {
 
 const openCropperWindow = async () => {
   closeAllCroppers();
+  if (checkForAnyBlockingEditors()) {
+    return;
+  }
 
   const recordAudio = settings.get('recordAudio');
 

--- a/main/menus.js
+++ b/main/menus.js
@@ -42,17 +42,17 @@ Workaround:           A workaround for the issue if you've found on. (this will 
 const openFileItem = {
   label: 'Open Video…',
   accelerator: 'Command+O',
-  click: () => {
+  click: async () => {
     closeAllCroppers();
 
-    dialog.showOpenDialogSync({
+    const {canceled, filePaths} = await dialog.showOpenDialog({
       filters: [{name: 'Videos', extensions: supportedVideoExtensions}],
-      properties: ['openFile']
-    }, filePaths => {
-      if (filePaths) {
-        openFiles(...filePaths);
-      }
+      properties: ['openFile', 'multiSelections']
     });
+
+    if (!canceled && filePaths) {
+      openFiles(...filePaths);
+    }
   }
 };
 

--- a/renderer/components/editor/options/index.js
+++ b/renderer/components/editor/options/index.js
@@ -13,10 +13,11 @@ export default class Options extends React.Component {
           .container {
             display: flex;
             flex: 1;
-            margin: 0 16px;
+            padding: 0 16px;
             align-items: center;
             justify-content: space-between;
             width: 100%;
+            background: var(--background-color);
           }
         `}</style>
       </div>

--- a/renderer/components/exports/index.js
+++ b/renderer/components/exports/index.js
@@ -29,6 +29,7 @@ class Exports extends React.Component {
         <style jsx>{`
             flex: 1;
             overflow-y: auto;
+            background: var(--background-color);
         `}</style>
       </div>
     );

--- a/renderer/pages/editor.js
+++ b/renderer/pages/editor.js
@@ -78,6 +78,7 @@ export default class EditorPage extends React.Component {
             --slider-popup-background: rgba(255, 255, 255, 0.85);
             --slider-background-color: #ffffff;
             --slider-thumb-color: #ffffff;
+            --background-color: #222222;
           }
 
           .dark {

--- a/renderer/pages/exports.js
+++ b/renderer/pages/exports.js
@@ -49,11 +49,13 @@ export default class ExportsPage extends React.Component {
             :root {
               --thumbnail-overlay-color: rgba(0, 0, 0, 0.4);
               --row-hover-color: #f9f9f9;
+              --background-color: #fff;
             }
 
             .dark {
               --thumbnail-overlay-color: rgba(0, 0, 0, 0.2);
               --row-hover-color: rgba(255, 255, 255, 0.1);
+              --background-color: #222222;
             }
         `}</style>
       </div>


### PR DESCRIPTION
Actually fixes #709 after debugging with @skllcrn on the current master and fixes some window background styles for dark mode.

The issue for #709 was that the app becomes inactive when the dialogs are open in the croppers (the not saved dialogs) so you can't interact with any other window (or even the tray). However, the accelerator was still active, so if you used it, it would open the cropper, but the app was still inactive and you wouldn't be able to click through the cropper. 

Since we can't close the dialogs, the next best thing was to not open the cropper until the editor dialogs are closed, to prevent the user from getting to that unresponsive stuck state