### PR TITLE
Bug fixes

### DIFF
--- a/main/export-options.js
+++ b/main/export-options.js
@@ -60,7 +60,8 @@ const getExportOptions = () => {
         }
       }
     } catch (error) {
-      console.log(error);
+      const Sentry = require('../utils/sentry');
+      Sentry.captureException(error);
     }
   }
 

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -60,7 +60,7 @@ const getExportOptions = () => {
         }
       }
     } catch (error) {
-      const Sentry = require('../utils/sentry');
+      const Sentry = require('./utils/sentry');
       Sentry.captureException(error);
     }
   }

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -46,17 +46,21 @@ const getExportOptions = () => {
       continue;
     }
 
-    const plugin = require(json.pluginPath);
+    try {
+      const plugin = require(json.pluginPath);
 
-    for (const service of plugin.shareServices) {
-      for (const format of service.formats) {
-        options.find(option => option.format === format).plugins.push({
-          title: service.title,
-          pluginName: json.name,
-          pluginPath: json.pluginPath,
-          apps: json.name === '_openWith' ? apps.get(format) : undefined
-        });
+      for (const service of plugin.shareServices) {
+        for (const format of service.formats) {
+          options.find(option => option.format === format).plugins.push({
+            title: service.title,
+            pluginName: json.name,
+            pluginPath: json.pluginPath,
+            apps: json.name === '_openWith' ? apps.get(format) : undefined
+          });
+        }
       }
+    } catch (error) {
+      console.log(error);
     }
   }
 

--- a/main/plugin.js
+++ b/main/plugin.js
@@ -18,6 +18,7 @@ class Plugin {
     this.link = homepage || (links && links.homepage);
 
     this.config = new PluginConfig(pluginName, this.plugin);
+    this.validators = this.config.validators;
   }
 
   isConfigValid() {

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -86,6 +86,10 @@ export default class PreferencesContainer extends Container {
         pluginsFromNpm: pluginsFromNpm.filter(p => p.name !== name),
         pluginsInstalled: [plugin, ...pluginsInstalled].sort((a, b) => a.prettyName.localeCompare(b.prettyName))
       });
+    } else {
+      this.setState({
+        pluginBeingInstalled: null
+      });
     }
   }
 

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -82,13 +82,13 @@ export default class PreferencesContainer extends Container {
       plugin.isValid = isValid;
       plugin.hasConfig = hasConfig;
       this.setState({
-        pluginBeingInstalled: null,
+        pluginBeingInstalled: undefined,
         pluginsFromNpm: pluginsFromNpm.filter(p => p.name !== name),
         pluginsInstalled: [plugin, ...pluginsInstalled].sort((a, b) => a.prettyName.localeCompare(b.prettyName))
       });
     } else {
       this.setState({
-        pluginBeingInstalled: null
+        pluginBeingInstalled: undefined
       });
     }
   }


### PR DESCRIPTION
Fixes 3 bugs:

- When reading a plugin's config, if anything goes wrong it would crash and show an empty list. This way at that one will be omitted but at least the rest will show

- When opening the plugin config, it would be an empty window. That was introduced with the `Open With` PR, but fixed with this one

- When installing a plugin, if something went wrong (npm error, or connection), the app wouldn't catch it and not crash, but it remained in the `installing` state with every other plugin disabled. Now it will reset back, with the plugin remaining uninstalled