### PR TITLE
Use the `IconMenu` component in the `...` button in the export window

### DIFF
--- a/renderer/components/exports/export.js
+++ b/renderer/components/exports/export.js
@@ -27,18 +27,23 @@ export default class Export extends React.Component {
   }
 
   openFile = () => {
-    const {filePath, disableOutputActions} = this.props;
-    if (filePath && !disableOutputActions) {
+    const {filePath} = this.props;
+    if (this.isActionable) {
       electron.remote.shell.showItemInFolder(filePath);
     }
   }
 
   onDragStart = event => {
-    const {createdAt, disableOutputActions} = this.props;
+    const {createdAt} = this.props;
     event.preventDefault();
-    if (!disableOutputActions) {
+    if (this.isActionable) {
       electron.ipcRenderer.send('drag-export', createdAt);
     }
+  }
+
+  get isActionable() {
+    const {filePath, disableOutputActions} = this.props;
+    return filePath && !disableOutputActions;
   }
 
   render() {
@@ -55,8 +60,7 @@ export default class Export extends React.Component {
     const cancelable = status === 'waiting' || status === 'processing';
     const fileNameClassName = classNames({
       title: true,
-      'title-color': !cancelable,
-      'title-color-disabled': cancelable
+      disabled: !this.isActionable
     });
     return (
       <div draggable className="export-container" onClick={this.openFile} onDragStart={this.onDragStart}>
@@ -66,8 +70,7 @@ export default class Export extends React.Component {
             {
               cancelable ?
                 <div className="icon" onClick={cancel}>
-                  <CancelIcon className="icon" fill="white"
-                    hoverFill="white" activeFill="white"/>
+                  <CancelIcon fill="white" hoverFill="white" activeFill="white"/>
                 </div> :
                 <IconMenu fillParent icon={MoreIcon} fill="white"
                   hoverFill="white" activeFill="white"
@@ -139,13 +142,10 @@ export default class Export extends React.Component {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-          }
-
-          .title-color {
             color: var(--title-color);
           }
 
-          .title-color-disabled {
+          .disabled {
             color: var(--switch-disabled-color);
           }
 

--- a/renderer/components/exports/export.js
+++ b/renderer/components/exports/export.js
@@ -1,6 +1,7 @@
 import electron from 'electron';
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 
 import IconMenu from '../icon-menu';
 import {CancelIcon, MoreIcon} from '../../vectors';
@@ -52,7 +53,11 @@ export default class Export extends React.Component {
     const {menu} = this.state;
 
     const cancelable = status === 'waiting' || status === 'processing';
-
+    const fileNameClassName = classNames({
+      title: true,
+      'title-color': !cancelable,
+      'title-color-disabled': cancelable
+    });
     return (
       <div draggable className="export-container" onClick={this.openFile} onDragStart={this.onDragStart}>
         <div className="thumbnail">
@@ -80,7 +85,7 @@ export default class Export extends React.Component {
           </div>
         </div>
         <div className="details">
-          <div className={'title ' + (status === 'processing' ? 'title-color-disabled' : 'title-color')}>
+          <div className={fileNameClassName}>
             {defaultFileName}
           </div>
           <div className="subtitle">{text}</div>

--- a/renderer/components/exports/export.js
+++ b/renderer/components/exports/export.js
@@ -60,8 +60,13 @@ export default class Export extends React.Component {
           <div className="icon" onClick={stopPropagation}>
             {
               cancelable ?
-                <CancelIcon fill="white" hoverFill="white" activeFill="white" onClick={cancel}/> :
-                <IconMenu icon={MoreIcon} fill="white" hoverFill="white" activeFill="white" onOpen={menu && menu.popup}/>
+                <div className="icon" onClick={cancel}>
+                  <CancelIcon className="icon" fill="white"
+                    hoverFill="white" activeFill="white"/>
+                </div> :
+                <IconMenu fillParent icon={MoreIcon} fill="white"
+                  hoverFill="white" activeFill="white"
+                  onOpen={menu && menu.popup}/>
             }
           </div>
           <div className="progress">
@@ -75,7 +80,9 @@ export default class Export extends React.Component {
           </div>
         </div>
         <div className="details">
-          <div className="title">{defaultFileName}</div>
+          <div className={'title ' + (status === 'processing' ? 'title-color-disabled' : 'title-color')}>
+            {defaultFileName}
+          </div>
           <div className="subtitle">{text}</div>
         </div>
         <style jsx>{`
@@ -127,7 +134,14 @@ export default class Export extends React.Component {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+          }
+
+          .title-color {
             color: var(--title-color);
+          }
+
+          .title-color-disabled {
+            color: var(--switch-disabled-color);
           }
 
           .subtitle {

--- a/renderer/components/icon-menu.js
+++ b/renderer/components/icon-menu.js
@@ -5,7 +5,7 @@ class IconMenu extends React.Component {
   container = React.createRef();
 
   openMenu = () => {
-    const boundingRect = this.container.current.getBoundingClientRect();
+    const boundingRect = this.container.current.children[0].getBoundingClientRect();
     const {bottom, left} = boundingRect;
     const {onOpen} = this.props;
 
@@ -20,12 +20,14 @@ class IconMenu extends React.Component {
   render() {
     const {icon: Icon, ...iconProps} = this.props;
     return (
-      <div ref={this.container}>
-        <Icon {...iconProps} onClick={this.openMenu}/>
+      <div ref={this.container} onClick={this.openMenu}>
+        <Icon {...iconProps}/>
         <style jsx>{`
           display: flex;
           align-items: center;
           justify-content: center;
+          width: ${this.props.fillParent ? '100%' : 'none'};
+          height: ${this.props.fillParent ? '100%' : 'none'}
         `}</style>
       </div>
     );
@@ -34,7 +36,8 @@ class IconMenu extends React.Component {
 
 IconMenu.propTypes = {
   onOpen: PropTypes.elementType,
-  icon: PropTypes.elementType.isRequired
+  icon: PropTypes.elementType.isRequired,
+  fillParent: PropTypes.bool
 };
 
 export default IconMenu;


### PR DESCRIPTION
This PR fixes #559. I saw that the [previous PR](https://github.com/wulkano/kap/pull/594) was abandoned and closed so I thought I'd take over. 

A few mentions/questions regarding the code I've changed:

- I couldn't find a reason for which `onClick={this.openMenu}` was moved from container to icon in [this PR](https://github.com/wulkano/kap/pull/616/files#diff-bf39c262b039812c1eabc844a553e0d7R24). Unfortunately if the listener is set directly on the svg, we cannot make it fill the parent without making the svg look big
- Since nesting is not supported by styled-jsx, I thought the `title-color` classes would be the best option. Let me know if there's a better one
- Is using `switch-disabled-color` alright or would a custom `disabled-title` color be better?


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#559: The `...` button in the export window should use the `IconMenu` component](https://issuehunt.io/repos/65411043/issues/559)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->