### PR TITLE
Use yarn for plugin installation

### DIFF
--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -19,6 +19,7 @@ const {track} = require('./analytics');
 class Plugins {
   constructor() {
     this.npmBin = path.join(__dirname, '../../node_modules/npm/bin/npm-cli.js');
+    this.yarnBin = path.join(__dirname, '../../node_modules/yarn/bin/yarn.js');
     this._makePluginsDir();
     this.appVersion = app.getVersion();
   }
@@ -55,6 +56,15 @@ class Plugins {
     });
   }
 
+  async _runYarn(...commands) {
+    await execa(process.execPath, [this.yarnBin, ...commands], {
+      cwd: this.cwd,
+      env: {
+        ELECTRON_RUN_AS_NODE: 1
+      }
+    });
+  }
+
   _getPrettyName(name) {
     return name.replace(/^kap-/, '');
   }
@@ -68,8 +78,8 @@ class Plugins {
     return Object.keys(JSON.parse(pkg).dependencies);
   }
 
-  async _npmInstall() {
-    await this._runNpm('install', '--no-package-lock', '--registry', 'https://registry.npmjs.org');
+  async _yarnInstall() {
+    await this._runYarn('install', '--no-lockfile', '--registry', 'https://registry.npmjs.org');
   }
 
   async install(name) {
@@ -81,7 +91,7 @@ class Plugins {
     });
 
     try {
-      await this._npmInstall();
+      await this._yarnInstall();
 
       const plugin = new Plugin(name);
       const isValid = plugin.isConfigValid();
@@ -129,7 +139,7 @@ class Plugins {
   }
 
   async upgrade() {
-    await this._npmInstall();
+    await this._yarnInstall();
   }
 
   uninstall(name) {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "tempy": "^0.3.0",
     "tildify": "^2.0.0",
     "tmp": "^0.1.0",
-    "unstated": "^1.2.0"
+    "unstated": "^1.2.0",
+    "yarn": "^1.19.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9019,6 +9019,11 @@ yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
 
+yarn@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.19.1.tgz#14b92410dd1ba5bab87a12b4a3d807f4569bea97"
+  integrity sha512-gBnfbL9rYY05Gt0cjJhs/siqQXHYlZalTjK3nXn2QO20xbkIFPob+LlH44ML47GcR4VU9/2dYck1BWFM0Javxw==
+
 yauzl@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"


### PR DESCRIPTION
Fixes #753 

Uses yarn for plugin installation. Unfortunately yarn [doesn't support prune](https://github.com/yarnpkg/yarn/issues/696), so I kept the npm binary as well.

I tested locally can didn't get any errors. There wasn't specific STR, it just happened sometimes, so I'll do some more testing to make sure the issue is resolved