### PR TITLE
Notarize app during packaging

### DIFF
--- a/after-sign-hook.js
+++ b/after-sign-hook.js
@@ -10,7 +10,10 @@ module.exports = async function (params) {
     return;
   }
 
-  console.log('afterSign hook triggered', params);
+  // Only notarize the app on the master branch
+  if (process.env.CIRCLE_BRANCH !== 'master') {
+    return;
+  }
 
   // Same appId in electron-builder.
   const appId = 'com.wulkano.kap';

--- a/after-sign-hook.js
+++ b/after-sign-hook.js
@@ -1,11 +1,11 @@
 // See: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db
 
+'use strict';
 const fs = require('fs');
 const path = require('path');
 const electronNotarize = require('electron-notarize');
 
 module.exports = async function (params) {
-  // Only notarize the app on Mac OS only.
   if (process.platform !== 'darwin') {
     return;
   }
@@ -17,7 +17,7 @@ module.exports = async function (params) {
 
   const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
   if (!fs.existsSync(appPath)) {
-    throw new Error(`Cannot find application at: ${appPath}`);
+    throw new Error(`Cannot find app at: ${appPath}`);
   }
 
   console.log(`Notarizing ${appId} found at ${appPath}`);

--- a/after-sign-hook.js
+++ b/after-sign-hook.js
@@ -1,0 +1,37 @@
+// See: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db
+
+const fs = require('fs');
+const path = require('path');
+const electronNotarize = require('electron-notarize');
+
+module.exports = async function (params) {
+  // Only notarize the app on Mac OS only.
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  console.log('afterSign hook triggered', params);
+
+  // Same appId in electron-builder.
+  const appId = 'com.wulkano.kap';
+
+  const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`Cannot find application at: ${appPath}`);
+  }
+
+  console.log(`Notarizing ${appId} found at ${appPath}`);
+
+  try {
+    await electronNotarize.notarize({
+      appBundleId: appId,
+      appPath,
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_ID_PASSWORD
+    });
+  } catch (error) {
+    console.error(error);
+  }
+
+  console.log(`Done notarizing ${appId}`);
+};

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>

--- a/notarize.js
+++ b/notarize.js
@@ -5,23 +5,20 @@ const fs = require('fs');
 const path = require('path');
 const electronNotarize = require('electron-notarize');
 
-module.exports = async function (params) {
+module.exports = async params => {
   if (process.platform !== 'darwin') {
     return;
   }
 
   // Only notarize the app on the master branch
-  if (process.env.CIRCLE_BRANCH !== 'master') {
-    return;
-  }
+  // if (process.env.CIRCLE_BRANCH !== 'master') {
+  //   return;
+  // }
 
-  // Same appId in electron-builder.
-  const appId = 'com.wulkano.kap';
+  const packageJson = JSON.parse(fs.readFileSync('./package.json'));
+  const {appId} = packageJson.build;
 
   const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);
-  if (!fs.existsSync(appPath)) {
-    throw new Error(`Cannot find app at: ${appPath}`);
-  }
 
   console.log(`Notarizing ${appId} found at ${appPath}`);
 
@@ -34,6 +31,7 @@ module.exports = async function (params) {
     });
   } catch (error) {
     console.error(error);
+    return;
   }
 
   console.log(`Done notarizing ${appId}`);

--- a/notarize.js
+++ b/notarize.js
@@ -1,7 +1,6 @@
 // See: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db
 
 'use strict';
-const fs = require('fs');
 const path = require('path');
 const electronNotarize = require('electron-notarize');
 
@@ -11,9 +10,9 @@ module.exports = async params => {
   }
 
   // Only notarize the app on the master branch
-  // if (process.env.CIRCLE_BRANCH !== 'master') {
-  //   return;
-  // }
+  if (process.env.CIRCLE_BRANCH !== 'master') {
+    return;
+  }
 
   const packageJson = require('./package.json');
   const {appId} = packageJson.build;
@@ -22,17 +21,12 @@ module.exports = async params => {
 
   console.log(`Notarizing ${appId} found at ${appPath}`);
 
-  try {
-    await electronNotarize.notarize({
-      appBundleId: appId,
-      appPath,
-      appleId: process.env.APPLE_ID,
-      appleIdPassword: process.env.APPLE_ID_PASSWORD
-    });
-  } catch (error) {
-    console.error(error);
-    return;
-  }
+  await electronNotarize.notarize({
+    appBundleId: appId,
+    appPath,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_ID_PASSWORD
+  });
 
   console.log(`Done notarizing ${appId}`);
 };

--- a/notarize.js
+++ b/notarize.js
@@ -15,7 +15,7 @@ module.exports = async params => {
   //   return;
   // }
 
-  const packageJson = JSON.parse(fs.readFileSync('./package.json'));
+  const packageJson = require('./package.json');
   const {appId} = packageJson.build;
 
   const appPath = path.join(params.appOutDir, `${params.packager.appInfo.productFilename}.app`);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "electron-better-ipc": "^0.5.0",
     "electron-log": "^3.0.7",
     "electron-next": "^3.1.5",
+    "electron-notarize": "^0.2.0",
     "electron-store": "^5.0.0",
     "electron-updater": "^4.1.2",
     "electron-util": "^0.12.1",
@@ -116,6 +117,7 @@
   },
   "build": {
     "appId": "com.wulkano.kap",
+    "afterSign": "./after-sign-hook.js",
     "files": [
       "**/*",
       "!renderer",
@@ -126,6 +128,8 @@
       "category": "public.app-category.productivity",
       "minimumSystemVersion": "10.12.0",
       "darkModeSupport": true,
+      "hardenedRuntime": true,
+      "entitlements": "./build/entitlements.mac.inherit.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Kap needs access to the microphone to be able to record audio for screen recordings.",
         "NSUserNotificationAlertStyle": "alert",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "build": {
     "appId": "com.wulkano.kap",
-    "afterSign": "./after-sign-hook.js",
+    "afterSign": "./notarize.js",
     "files": [
       "**/*",
       "!renderer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,6 +2791,14 @@ electron-next@^3.1.5:
     app-root-path ">=2.0.1"
     electron-is-dev ">=0.3.0"
 
+electron-notarize@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-0.2.0.tgz#676c71688ee84149bab27b22426d0a9452e7e262"
+  integrity sha512-u3KdEMOEcGMF9yCML8ej4ZF+O29VmGYIjrs/DoOi23neTWOMiIc5YCeFs4vxq3JG496omcw7Y5pimPm0sH9A7g==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^8.1.0"
+
 electron-publish@21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-21.2.0.tgz#cc225cb46aa62e74b899f2f7299b396c9802387d"


### PR DESCRIPTION
Fixes #754 

Tried following this guide: https://medium.com/@TwitterArchiveEraser/notarize-electron-apps-7a5f988406db

Need `APPLE_ID` and `APPLE_ID_PASSWORD` set in CI