### PR TITLE
Fix plugin usage history

### DIFF
--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -207,6 +207,6 @@ export default class EditorContainer extends Container {
     };
 
     ipc.callMain('export', data);
-    ipc.callMain('update-usage', {format, plugin: plugin.name});
+    ipc.callMain('update-usage', {format, plugin: plugin.pluginName});
   }
 }


### PR DESCRIPTION
Fix #766 

At some point we renamed the `name` field on the plugins to `pluginName` but forgot to update it here. So it was updating the `undefined` plugin every time.

Stuff like this makes me wonder if it's worth looking into slowly converting this to TypeScript