### PR TITLE
Fix prompt that is shown when quitting while exporting

### DIFF
--- a/main/export-list.js
+++ b/main/export-list.js
@@ -19,6 +19,7 @@ const {getExportsWindow, openExportsWindow} = require('./exports');
 const {openEditorWindow} = require('./editor');
 const {toggleExportMenuItem} = require('./menus');
 const Export = require('./export');
+const {ensureDockIsShowingSync} = require('./utils/dock');
 
 const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
 let lastSavedDirectory;
@@ -266,23 +267,24 @@ module.exports = () => {
   app.on('before-quit', event => {
     if (exportList.currentExport) {
       openExportsWindow();
-      const exportsWindow = getExportsWindow();
 
-      const buttonIndex = dialog.showMessageBoxSync(exportsWindow, {
-        type: 'question',
-        buttons: [
-          'Continue',
-          'Quit'
-        ],
-        defaultId: 0,
-        cancelId: 1,
-        message: 'Do you want to continue exporting?',
-        detail: 'Kap is currently exporting files. If you quit, the export task will be canceled.'
+      ensureDockIsShowingSync(() => {
+        const buttonIndex = dialog.showMessageBoxSync({
+          type: 'question',
+          buttons: [
+            'Continue',
+            'Quit'
+          ],
+          defaultId: 0,
+          cancelId: 1,
+          message: 'Do you want to continue exporting?',
+          detail: 'Kap is currently exporting files. If you quit, the export task will be canceled.'
+        });
+
+        if (buttonIndex === 0) {
+          event.preventDefault();
+        }
       });
-
-      if (buttonIndex === 0) {
-        event.preventDefault();
-      }
     }
   });
 };

--- a/main/utils/dock.js
+++ b/main/utils/dock.js
@@ -13,6 +13,20 @@ const ensureDockIsShowing = async action => {
   }
 };
 
+const ensureDockIsShowingSync = action => {
+  const wasDockShowing = app.dock.isVisible();
+  if (!wasDockShowing) {
+    app.dock.show();
+  }
+
+  action();
+
+  if (!wasDockShowing) {
+    app.dock.hide();
+  }
+};
+
 module.exports = {
-  ensureDockIsShowing
+  ensureDockIsShowing,
+  ensureDockIsShowingSync
 };


### PR DESCRIPTION
Fixes #772

Issue is that our export window creation is async (to avoid flash when data arrives), but the event `before-quite` has to be handled synchronously (to call `preventDefault` if the user wants to continue).

Couldn't find a good solution, so for now it shows the message floating, not attached to the exports window.

Other solution might be somehow turning the exports window creation to sync?