### PR TITLE
Allow configure highlight click settings from macOS high sierra

### DIFF
--- a/renderer/components/preferences/categories/general.js
+++ b/renderer/components/preferences/categories/general.js
@@ -24,7 +24,7 @@ class General extends React.Component {
 
   componentDidMount() {
     this.setState({
-      showCursorSupported: electron.remote.require('./utils/macos-version').isGreaterThanOrEqualTo('10.14')
+      showCursorSupported: electron.remote.require('./utils/macos-version').isGreaterThanOrEqualTo('10.13')
     });
   }
 


### PR DESCRIPTION
Addressing Issue https://github.com/wulkano/kap/issues/784

As I mentioned in that issue I've tested this on my machine which runs macOS high sierra

![image](https://user-images.githubusercontent.com/101433/73086930-59cd1480-3eb0-11ea-8d2f-80e8be22d6b7.png)

![Kapture 2020-01-24 at 13 46 37](https://user-images.githubusercontent.com/101433/73086771-035fd600-3eb0-11ea-8963-60858de97a1c.gif)
![image](https://user-images.githubusercontent.com/101433/73086812-15da0f80-3eb0-11ea-9f5a-948cc01d6d4b.png)
![Kapture 2020-01-24 at 13 47 55](https://user-images.githubusercontent.com/101433/73086841-25595880-3eb0-11ea-9792-bc82904b191f.gif)



