### PR TITLE
Remember FPS preference across editors

### DIFF
--- a/main/editor.js
+++ b/main/editor.js
@@ -14,6 +14,7 @@ const loadRoute = require('./utils/routes');
 
 const editors = new Map();
 let exportOptions;
+let exportFps;
 const OPTIONS_BAR_HEIGHT = 48;
 const VIDEO_ASPECT = 9 / 16;
 const MIN_VIDEO_WIDTH = 768;
@@ -90,14 +91,15 @@ const openEditorWindow = async (filePath, {recordedFps, isNewRecording, original
   });
 
   editorWindow.webContents.on('did-finish-load', async () => {
-    ipc.callRenderer(editorWindow, 'export-options', exportOptions);
+    ipc.callRenderer(editorWindow, 'export-options', {exportOptions, fps: exportFps});
     await ipc.callRenderer(editorWindow, 'file', {filePath, fps, originalFilePath, isNewRecording});
     editorWindow.show();
   });
 };
 
-const setOptions = options => {
+const setOptions = ({options, fps}) => {
   exportOptions = options;
+  exportFps = fps;
 };
 
 const getEditors = () => editors.values();

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -19,6 +19,13 @@ const exportUsageHistory = new Store({
   }
 });
 
+const fpsUsageHistory = new Store({
+  name: 'fps-usage-history',
+  defaults: {
+    fps: 60
+  }
+});
+
 const prettifyFormat = format => {
   const formats = new Map([
     ['apng', 'APNG'],
@@ -86,23 +93,24 @@ const updateExportOptions = () => {
     ipc.callRenderer(editor, 'export-options', exportOptions);
   }
 
-  setOptions(exportOptions);
+  setOptions({options: exportOptions, fps: fpsUsageHistory.get('fps')});
 };
 
 plugins.setUpdateExportOptions(updateExportOptions);
 
-ipc.answerRenderer('update-usage', ({format, plugin}) => {
+ipc.answerRenderer('update-usage', ({format, plugin, fps}) => {
   const usage = exportUsageHistory.get(format);
   const now = Date.now();
 
   usage.plugins[plugin] = now;
   usage.lastUsed = now;
   exportUsageHistory.set(format, usage);
+  fpsUsageHistory.set('fps', fps);
   updateExportOptions();
 });
 
 const initializeExportOptions = () => {
-  setOptions(getExportOptions());
+  setOptions({options: getExportOptions(), fps: fpsUsageHistory.get('fps')});
 };
 
 module.exports = {

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -21,8 +21,12 @@ const exportUsageHistory = new Store({
 
 const fpsUsageHistory = new Store({
   name: 'fps-usage-history',
-  defaults: {
-    fps: 60
+  schema: {
+    fps: {
+      type: 'number',
+      minimum: 0,
+      default: 60
+    }
   }
 });
 

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -7,7 +7,7 @@ const isMuted = format => ['gif', 'apng'].includes(format);
 
 export default class EditorContainer extends Container {
   state = {
-    fps: 15
+    fps: 60
   }
 
   setVideoContainer = videoContainer => {
@@ -20,7 +20,17 @@ export default class EditorContainer extends Container {
     const src = `file://${filePath}`;
     this.finishLoading = resolve;
 
-    this.setState({src, filePath, originalFilePath, fps, originalFps: fps, wasMuted: false, isNewRecording});
+    this.setState({
+      src,
+      filePath,
+      originalFilePath,
+      // TODO: Fix this ESLint violation
+      // eslint-disable-next-line react/no-access-state-in-setstate
+      fps: Math.min(fps, this.state.fps),
+      originalFps: fps,
+      wasMuted: false,
+      isNewRecording
+    });
     this.videoContainer.setSrc(src);
   }
 
@@ -96,9 +106,9 @@ export default class EditorContainer extends Container {
     this.setState(updates);
   }
 
-  setOptions = options => {
+  setOptions = ({exportOptions: options, fps}) => {
     const {format, plugin} = this.state;
-    const updates = {options};
+    const updates = {options, fps: Math.min(fps, this.state.fps)};
 
     if (format) {
       const option = options.find(option => option.format === format);
@@ -221,6 +231,6 @@ export default class EditorContainer extends Container {
     };
 
     ipc.callMain('export', data);
-    ipc.callMain('update-usage', {format, plugin: plugin.pluginName});
+    ipc.callMain('update-usage', {format, plugin: plugin.pluginName, fps});
   }
 }


### PR DESCRIPTION
Save the fps used in an export in a similar way as we do for plugin usage and use that when the editor first loads. If your preference is let's say 45, but you recorded with 30 fps (or opened a video that has 30fps) the minimum of those values will be used﻿
