### PR TITLE
Make sure pause is not called before play is finished

### DIFF
--- a/renderer/components/editor/video.js
+++ b/renderer/components/editor/video.js
@@ -28,17 +28,18 @@ class Video extends React.Component {
   }
 
   contextMenu = () => {
+    const {play, pause} = this.props;
     const video = this.videoRef.current;
     const wasPaused = video.paused;
 
     if (!wasPaused) {
-      video.pause();
+      pause();
     }
 
     this.menu.popup({
       callback: () => {
         if (!wasPaused) {
-          video.play();
+          play();
         }
       }
     });
@@ -73,11 +74,13 @@ class Video extends React.Component {
 Video.propTypes = {
   src: PropTypes.string,
   setVideo: PropTypes.elementType,
-  getSnapshot: PropTypes.elementType
+  getSnapshot: PropTypes.elementType,
+  play: PropTypes.elementType,
+  pause: PropTypes.elementType
 };
 
 export default connect(
   [VideoContainer, EditorContainer],
   ({src}) => ({src}),
-  ({setVideo}, {getSnapshot}) => ({setVideo, getSnapshot})
+  ({setVideo, play, pause}, {getSnapshot}) => ({setVideo, getSnapshot, play, pause})
 )(Video);

--- a/renderer/containers/video.js
+++ b/renderer/containers/video.js
@@ -76,7 +76,7 @@ export default class VideoContainer extends Container {
       const {isReady} = this.state;
       if (!isReady) {
         this.editorContainer.load();
-        video.play();
+        this.play();
         this.setState({isReady: true});
       }
     });
@@ -99,11 +99,22 @@ export default class VideoContainer extends Container {
   }
 
   play = async () => {
-    await this.video.play();
-    this.setState({isPaused: false});
+    try {
+      this.playPromise = this.video.play();
+      await this.playPromise;
+      this.setState({isPaused: false});
+    } catch {
+      this.setState({isPaused: true});
+    } finally {
+      this.playPromise = undefined;
+    }
   }
 
-  pause = () => {
+  pause = async () => {
+    if (this.playPromise) {
+      await this.playPromise;
+    }
+
     this.video.pause();
     this.setState({isPaused: true});
   }


### PR DESCRIPTION
Fix this sentry issue:
https://sentry.io/organizations/wulkano-l0/issues/1230019159/?project=255536&query=&sort=freq&statsPeriod=14d

That has been triggered 698k times 

This is the error that is causing it: 
https://developers.google.com/web/updates/2017/06/play-request-was-interrupted

When basically `pause` is called before the `play` promise has resolved

Added a bunch of checks to make sure that doesn't happen any more