### PR TITLE
Fix UX for incompatible plugins

### DIFF
--- a/main/plugin.js
+++ b/main/plugin.js
@@ -41,6 +41,7 @@ class InstalledPlugin extends BasePlugin {
     const {homepage, links} = this.json;
     this.link = homepage || (links && links.homepage);
     this.isCompatible = semver.satisfies(app.getVersion(), this.json.kapVersion || '*');
+    this.kapVersion = this.json.kapVersion;
 
     try {
       this.plugin = require(this.pluginPath);

--- a/renderer/components/preferences/categories/plugins/index.js
+++ b/renderer/components/preferences/categories/plugins/index.js
@@ -33,7 +33,13 @@ class Plugins extends React.Component {
     const allPlugins = [
       ...pluginsInstalled,
       ...pluginsFromNpm
-    ].sort((a, b) => a.prettyName.localeCompare(b.prettyName));
+    ].sort((a, b) => {
+      if (a.isCompatible !== b.isCompatible) {
+        return b.isCompatible - a.isCompatible;
+      }
+
+      return a.prettyName.localeCompare(b.prettyName);
+    });
 
     return (
       <Category>

--- a/renderer/components/preferences/categories/plugins/plugin.js
+++ b/renderer/components/preferences/categories/plugins/plugin.js
@@ -41,8 +41,10 @@ PluginTitle.propTypes = {
 };
 
 const Plugin = ({plugin, checked, disabled, onTransitionEnd, onClick, loading, openConfig, tabIndex}) => {
+  const requiredVersion = !plugin.isCompatible && `Requires Kap version ${plugin.kapVersion}.`;
+
   const error = !plugin.isCompatible && (
-    <div className="invalid" title={`This plugin is not supported by the current Kap version. Requires ${plugin.kapVersion}`}>
+    <div className="invalid" title={`This plugin is not supported. ${requiredVersion}`}>
       <ErrorIcon fill="#ff6059" hoverFill="#ff6059" onClick={openConfig}/>
       <style jsx>{`
         .invalid {
@@ -94,7 +96,7 @@ const Plugin = ({plugin, checked, disabled, onTransitionEnd, onClick, loading, o
           label={plugin.version}
           onClick={onTitleClick}/>
       }
-      subtitle={plugin.description}
+      subtitle={[plugin.description, requiredVersion].filter(Boolean)}
     >
       {
         openConfig && plugin.isCompatible && (


### PR DESCRIPTION
<img width="592" alt="Screen Shot 2020-03-25 at 12 24 28 PM" src="https://user-images.githubusercontent.com/8822835/77560596-11bc7500-6e94-11ea-93af-3cc8bec4f864.png">

Fixes #811
Fixes #815

Makes it easier for people to understand why those are disabled

Sorts them to bottom and adds a message