### PR TITLE
Fix editor options bug

### DIFF
--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -255,12 +255,11 @@ class Plugins {
       pluginPath: './plugins/save-file-plugin',
       isCompatible: true,
       name: '_saveToDisk'
+    }, {
+      pluginPath: './plugins/open-with-plugin',
+      isCompatible: true,
+      name: '_openWith'
     }];
-    // , {
-    //   pluginPath: './plugins/open-with-plugin',
-    //   isCompatible: true,
-    //   name: '_openWith'
-    // }
   }
 
   async getFromNpm() {

--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -255,11 +255,13 @@ class Plugins {
       pluginPath: './plugins/save-file-plugin',
       isCompatible: true,
       name: '_saveToDisk'
-    }, {
-      pluginPath: './plugins/open-with-plugin',
-      isCompatible: true,
-      name: '_openWith'
-    }];
+    }
+    // , {
+    //   pluginPath: './plugins/open-with-plugin',
+    //   isCompatible: true,
+    //   name: '_openWith'
+    // }
+    ];
   }
 
   async getFromNpm() {

--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -255,13 +255,12 @@ class Plugins {
       pluginPath: './plugins/save-file-plugin',
       isCompatible: true,
       name: '_saveToDisk'
-    }
+    }];
     // , {
     //   pluginPath: './plugins/open-with-plugin',
     //   isCompatible: true,
     //   name: '_openWith'
     // }
-    ];
   }
 
   async getFromNpm() {

--- a/main/editor.js
+++ b/main/editor.js
@@ -59,7 +59,7 @@ const openEditorWindow = async (
 
   editors.set(filePath, editorWindow);
 
-  loadRoute(editorWindow, 'editor');
+  loadRoute(editorWindow, 'editor', {openDevTools: true});
 
   if (isNewRecording) {
     editorWindow.setDocumentEdited(true);
@@ -99,6 +99,7 @@ const openEditorWindow = async (
   });
 
   editorWindow.webContents.on('did-finish-load', async () => {
+    ipc.callRenderer(editorWindow, 'export-options', allOptions);
     await ipc.callRenderer(editorWindow, 'file', {
       filePath,
       fps,
@@ -107,7 +108,6 @@ const openEditorWindow = async (
       recordingName,
       title
     });
-    ipc.callRenderer(editorWindow, 'export-options', allOptions);
     editorWindow.show();
   });
 };

--- a/main/editor.js
+++ b/main/editor.js
@@ -59,7 +59,7 @@ const openEditorWindow = async (
 
   editors.set(filePath, editorWindow);
 
-  loadRoute(editorWindow, 'editor', {openDevTools: true});
+  loadRoute(editorWindow, 'editor');
 
   if (isNewRecording) {
     editorWindow.setDocumentEdited(true);

--- a/main/utils/routes.js
+++ b/main/utils/routes.js
@@ -3,12 +3,15 @@
 const {app} = require('electron');
 const {is} = require('electron-util');
 
-const loadRoute = (win, routeName) => {
+const loadRoute = (win, routeName, {openDevTools} = {}) => {
   if (is.development) {
     win.loadURL(`http://localhost:8000/${routeName}`);
     win.openDevTools({mode: 'detach'});
   } else {
     win.loadFile(`${app.getAppPath()}/renderer/out/${routeName}.html`);
+    if (openDevTools) {
+      win.openDevTools({mode: 'detach'});
+    }
   }
 };
 

--- a/renderer/components/editor/options/select.js
+++ b/renderer/components/editor/options/select.js
@@ -51,7 +51,7 @@ class Select extends React.Component {
   }
 
   render() {
-    const {options, selected, clearable} = this.props;
+    const {options = [], selected, clearable} = this.props;
     const selectedOption = options.find(opt => opt.value === selected);
     const label = selectedOption && selectedOption.label;
 

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -118,7 +118,7 @@ export default class EditorContainer extends Container {
     ipc.callMain('refresh-usage');
   }
 
-  setOptions = ({exportOptions, editOptions, fps}) => {
+  setOptions = ({exportOptions = [], editOptions = [], fps}) => {
     console.log('Got options from main', exportOptions, editOptions, fps);
     const {format, plugin, editPlugin} = this.state;
     const updates = {options: exportOptions, editOptions};

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -127,6 +127,8 @@ export default class EditorContainer extends Container {
       updates.fps = Math.min(fps, this.state.fps);
     }
 
+    console.log('Updates', updates);
+
     if (format) {
       const option = exportOptions.find(option => option.format === format);
 
@@ -141,10 +143,13 @@ export default class EditorContainer extends Container {
       updates.plugin = title === 'Open With' ? secondTitle : title;
     }
 
+    console.log('Updates', updates);
+
     if (editPlugin) {
       updates.editPlugin = editOptions.find(({title, pluginName}) => title === editPlugin.title && pluginName === editPlugin.pluginName);
     }
 
+    console.log('Made it to updates', updates);
     this.setState(updates);
   }
 

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -119,6 +119,7 @@ export default class EditorContainer extends Container {
   }
 
   setOptions = ({exportOptions, editOptions, fps}) => {
+    console.log('Got options from main', exportOptions, editOptions, fps);
     const {format, plugin, editPlugin} = this.state;
     const updates = {options: exportOptions, editOptions};
 

--- a/renderer/containers/editor.js
+++ b/renderer/containers/editor.js
@@ -119,7 +119,6 @@ export default class EditorContainer extends Container {
   }
 
   setOptions = ({exportOptions = [], editOptions = [], fps}) => {
-    console.log('Got options from main', exportOptions, editOptions, fps);
     const {format, plugin, editPlugin} = this.state;
     const updates = {options: exportOptions, editOptions};
 
@@ -127,29 +126,24 @@ export default class EditorContainer extends Container {
       updates.fps = Math.min(fps, this.state.fps);
     }
 
-    console.log('Updates', updates);
-
     if (format) {
       const option = exportOptions.find(option => option.format === format);
 
       if (!option.plugins.find(p => p.title === plugin)) {
-        const [{title}, {title: secondTitle}] = option.plugins;
+        const [{title}, {title: secondTitle} = {}] = option.plugins;
         updates.plugin = title === 'Open With' ? secondTitle : title;
       }
     } else {
       const [option] = exportOptions;
-      const [{title}, {title: secondTitle}] = option.plugins;
+      const [{title}, {title: secondTitle} = {}] = option.plugins;
       updates.format = option.format;
       updates.plugin = title === 'Open With' ? secondTitle : title;
     }
-
-    console.log('Updates', updates);
 
     if (editPlugin) {
       updates.editPlugin = editOptions.find(({title, pluginName}) => title === editPlugin.title && pluginName === editPlugin.pluginName);
     }
 
-    console.log('Made it to updates', updates);
     this.setState(updates);
   }
 


### PR DESCRIPTION
This PR attempts to debug the editor bug where the options don't appear. After we pinpoint the issue it'll contain the fix

Okay, few, figured it out after hours of super slow experimenting. My old macbook can barely run, so imagine running a VM on it, and trying to run visual applications. It was hell. But the bug was a sneaky one. So, it turns out it's not because they are on 10.13 per se, but it did mean they were the only ones able to see it. So, the bug would happen for everyone that only had 1 plugin for a format. But since we have the built-in ones, we have save to disk, copy to clipboard and open with, so 2 for mp4 webm (since no clipboard) and 3 for gif, apng. So, no way to get 1 plugin, so we never see the bug. Well, if you are below 10.14.4, the package open-with doesn't work unless you have the Swift runtime libs thing, but we built it well in a way that it doesn't break, it just doesn't add that plugin, which brings those users (if they have no plugins) to 1 plugin for mp4/webm (only save to disk), which then causes the bug. The bug itself was 2 lines: https://github.com/wulkano/kap/pull/827/files#diff-206b3e1cacb7c4112db05c82a975cdf2R133-R138 But because of the explanation above we just could not trigger it unless we were on 10.13 or lower. Few. Anyway, bug is (hopefully) fixed, but figured I'd share my journey

Fixes #824 