### PR TITLE
Rename Zeit to Vercel in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Download [`master`](https://kap-artifacts.now.sh/master) or builds for any other
 
 ## Thanks
 
-- [▲ Vercel](https://vercel.com/) for the README formatting and for [hosting our downloads and updates](https://vercel.com/).
+- [▲ Vercel](https://vercel.com/) for the README formatting and for hosting our downloads and updates.
 - [● CircleCI](https://circleci.com/) for supporting the Open Source community and making our builds fast and reliable.
 - [△ Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
 - Our [contributors](https://github.com/wulkano/kap/contributors) who help maintain Kap and make screen recording and sharing easy.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Download [`master`](https://kap-artifacts.now.sh/master) or builds for any other
 
 ## Thanks
 
-- [▲ ZEIT](https://zeit.co/) for the README formatting and for [hosting our downloads and updates](https://zeit.co/now/).
+- [▲ Vercel](https://vercel.com/) for the README formatting and for [hosting our downloads and updates](https://vercel.com/).
 - [● CircleCI](https://circleci.com/) for supporting the Open Source community and making our builds fast and reliable.
 - [△ Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
 - Our [contributors](https://github.com/wulkano/kap/contributors) who help maintain Kap and make screen recording and sharing easy.


### PR DESCRIPTION
Zeit went through a rebrand. Also, Zeit Now is also just referenced as Vercel.