### PR TITLE
Improve error handling

### DIFF
--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -135,8 +135,6 @@ const startRecording = async options => {
 
   await callPlugins('willStartRecording');
 
-  console.log('Here');
-
   try {
     await aperture.startRecording(apertureOptions);
   } catch (error) {

--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -50,7 +50,7 @@ const callPlugins = async method => Promise.all(recordingPlugins.map(async ({plu
         })
       );
     } catch (error) {
-      showError(error, {title: `Something went wrong while using “${plugin.name}”`});
+      showError(error, {title: `Something went wrong while using the plugin “${plugin.prettyName}”`});
     }
   }
 }));

--- a/main/common/aperture.js
+++ b/main/common/aperture.js
@@ -50,7 +50,7 @@ const callPlugins = async method => Promise.all(recordingPlugins.map(async ({plu
         })
       );
     } catch (error) {
-      showError(error);
+      showError(error, {title: `Something went wrong while using “${plugin.name}”`});
     }
   }
 }));
@@ -135,12 +135,15 @@ const startRecording = async options => {
 
   await callPlugins('willStartRecording');
 
+  console.log('Here');
+
   try {
     await aperture.startRecording(apertureOptions);
   } catch (error) {
     track('recording/stopped/error');
     showError(error, {title: 'Recording error', reportToSentry: true});
     past = null;
+    cleanup();
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "aperture": "^5.2.0",
     "base64-img": "^1.0.4",
     "classnames": "^2.2.6",
+    "clean-stack": "^2.2.0",
     "delay": "^4.3.0",
     "electron-better-ipc": "^0.8.0",
     "electron-log": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,6 +2529,11 @@ clean-regexp@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+clean-stack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
 cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"


### PR DESCRIPTION
`showErrorBox` is a sync method, which not only blocks, but also doesn't let you interact with the app until the dialog is dismissed. This created a really bad bug when a recording plugin failed in the `willStartRecording` phase, since it would show a dialog with the error, which would be under the cropper, so you couldn't close the dialog but also couldn't dismiss the cropper since the app forces you to interact with the error box first.

Ideally, the error box should be async, and not blocking, so I switched to using `showMessageBox` with type `error`, along with some other optimizations from `electron-unhandled` (including a button to copy the error). 

However, that method blocks main process as well, which means it's not really async either. I've opened an issue for it: https://github.com/electron/electron/issues/23319. There used to be a way to make it async with a callback, but when it was split to sync/async methods they both became blocking. 

This is still better than `showErrorBox` since you can at least interact with the dialog, so it still fixes the bug described above, but for it to work perfectly we would need the above issue resolved.

This PR also adds a call to `cleanup` in case aperture fails to start recording, which will ensure the croppers and tray get reset, taking care of another rare bug.