### PR TITLE
Improve the order of the menu items

### DIFF
--- a/main/menus.js
+++ b/main/menus.js
@@ -109,7 +109,7 @@ const getCogMenuTemplate = () => [
   {
     type: 'separator'
   },
-  sendFeedbackItem,
+  preferencesItem,
   {
     type: 'separator'
   },
@@ -122,7 +122,7 @@ const getCogMenuTemplate = () => [
   {
     type: 'separator'
   },
-  preferencesItem,
+  sendFeedbackItem,
   {
     type: 'separator'
   },


### PR DESCRIPTION
#### Before

<img width="213" alt="Screenshot 2020-04-29 at 23 28 34" src="https://user-images.githubusercontent.com/170270/80614563-30082880-8a71-11ea-90b6-81ea1d5462eb.png">

#### After

<img width="213" alt="Screenshot 2020-04-29 at 23 27 30" src="https://user-images.githubusercontent.com/170270/80614632-42826200-8a71-11ea-98f1-cfafc106e57a.png">

---

I feel like this is a better order. It's also makes it the same as the `Kap` menu in the editor and also makes it easier to reach "Preferences…" in the cropper:

<img width="212" alt="Screenshot 2020-04-29 at 23 27 41" src="https://user-images.githubusercontent.com/170270/80614697-562dc880-8a71-11ea-8f25-f4ff4ce42799.png">
