### PR TITLE
Fix export time estimate

### DIFF
--- a/main/convert.js
+++ b/main/convert.js
@@ -61,7 +61,7 @@ const getConvertFunction = shouldTrack => (outputPath, options, args) => {
         // Wait 2 second in the conversion for the speed to be stable
         if (processedMs > 2 * 1000) {
           const msRemaining = (durationMs - processedMs) / speed;
-          options.onProgress(progress, prettyMs(Math.max(msRemaining, 1000), {compact: true}).slice(1));
+          options.onProgress(progress, prettyMs(Math.max(msRemaining, 1000), {compact: true}));
         } else {
           options.onProgress(progress);
         }


### PR DESCRIPTION
Fixes #852 

`pretty-ms` removed the `~` for compact [here](https://github.com/sindresorhus/pretty-ms/releases/tag/v6.0.0), but we forgot to make the update, so out `slice` to remove the `~`, was actually trimming the time