### PR TITLE
Allow plugins to specify `macosVersions` they support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,7 +19,11 @@ Tip: You can use modern JavaScript features like async/await in your plugin.
 - The `"description"` in package.json should succinctly describe what you can do with it. For example: `Share GIFs on GIPHY`. Not something like this: `Kap plugin that uploads GIFs to GIPHY`.
 - The readme should follow the style of [`kap-giphy`](https://github.com/wulkano/kap-giphy).
 - Your plugin must be tested, preferably using [`kap-plugin-test`](https://github.com/SamVerschueren/kap-plugin-test) and [`kap-plugin-mock-context`](https://github.com/samverschueren/kap-plugin-mock-context). [Example](https://github.com/wulkano/kap-giphy/blob/master/test/test.js).
-- If your plugin only supports specific versions of Kap, include a `kapVersion` field in the package.json with a [semver range](https://nodesource.com/blog/semver-a-primer/).
+- The package.json file can include a `kap` object with the following options:
+    - `version`: a [semver range](https://nodesource.com/blog/semver-a-primer/) of the Kap versions your plugin supports. Defaults to `*`.
+    - `macosVersion`: a [semver range](https://nodesource.com/blog/semver-a-primer/) of the macOS versions your plugin supports. Defaults to `*`.
+
+- **DEPRECATED** If your plugin only supports specific versions of Kap, include a `kapVersion` field in the package.json with a [semver range](https://nodesource.com/blog/semver-a-primer/). This is still supported but will be removed at some point in favor of `kap.version`.
 
 ## Development
 

--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -207,7 +207,11 @@ class Plugins {
 
     plugin.config.clear();
     this.updateExportOptions();
-    return new NpmPlugin(plugin.json, plugin.json.kapVersion);
+    return new NpmPlugin(plugin.json, {
+      // Keeping for backwards compatibility
+      version: plugin.json.kapVersion,
+      ...plugin.json.kap
+    });
   }
 
   async prune() {
@@ -272,8 +276,12 @@ class Plugins {
       .filter(x => x.name.startsWith('kap-'))
       .filter(x => !installed.includes(x.name)) // Filter out installed plugins
       .map(async x => {
-        const {kapVersion = '*'} = await packageJson(x.name, {fullMetadata: true});
-        return new NpmPlugin(x, kapVersion);
+        const {kap, kapVersion} = await packageJson(x.name, {fullMetadata: true});
+        return new NpmPlugin(x, {
+          // Keeping for backwards compatibility
+          version: kapVersion,
+          ...kap
+        });
       }));
   }
 

--- a/renderer/components/preferences/categories/plugins/plugin.js
+++ b/renderer/components/preferences/categories/plugins/plugin.js
@@ -41,7 +41,10 @@ PluginTitle.propTypes = {
 };
 
 const Plugin = ({plugin, checked, disabled, onTransitionEnd, onClick, loading, openConfig, tabIndex}) => {
-  const requiredVersion = !plugin.isCompatible && `Requires Kap version ${plugin.kapVersion}.`;
+  const requiredVersion = !plugin.isCompatible && (
+    (plugin.kapVersion && `Requires Kap version ${plugin.kapVersion}.`) ||
+    (plugin.macosVersion && `Requires macOS version ${plugin.macosVersion}`)
+  );
 
   const error = !plugin.isCompatible && (
     <div className="invalid" title={`This plugin is not supported. ${requiredVersion}`}>


### PR DESCRIPTION
Fixes #841

Creates the `kap` namespace for package.json and adds `macosVersion` as an option.

I kept backwards compatibility with `kapVersion` with a deprecated message. We can remove once we know that all plugins have migrated