### PR TITLE
Only start editor playback on load if the editor is focused

### DIFF
--- a/renderer/containers/video.js
+++ b/renderer/containers/video.js
@@ -1,4 +1,5 @@
 import {Container} from 'unstated';
+import electron from 'electron';
 
 export default class VideoContainer extends Container {
   state = {
@@ -76,7 +77,11 @@ export default class VideoContainer extends Container {
       const {isReady} = this.state;
       if (!isReady) {
         this.editorContainer.load();
-        this.play();
+
+        if (electron.remote.getCurrentWindow().isFocused()) {
+          this.play();
+        }
+
         this.setState({isReady: true});
       }
     });


### PR DESCRIPTION
Fixes #853 

This is pretty hard to achieve 😂  I was only able to test it with a very long recording that takes a split second to load, so I can blur between the editor opening and the video starting.