### PR TITLE
Allow plugin control via deep links

### DIFF
--- a/main/preferences.js
+++ b/main/preferences.js
@@ -16,6 +16,10 @@ const openPrefsWindow = async options => {
   closeAllCroppers();
 
   if (prefsWindow) {
+    if (options) {
+      ipc.callRenderer(prefsWindow, 'options', options);
+    }
+
     prefsWindow.show();
     return prefsWindow;
   }

--- a/main/utils/deep-linking.js
+++ b/main/utils/deep-linking.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const {openPrefsWindow} = require('../preferences');
 const pluginPromises = new Map();
 
 const handlePluginsDeepLink = path => {
@@ -18,8 +19,12 @@ const addPluginPromise = (plugin, resolveFunction) => {
   pluginPromises.set(plugin, resolveFunction);
 };
 
+const triggerPluginAction = action => name => openPrefsWindow({target: {name, action}});
+
 const routes = new Map([
-  ['plugins', handlePluginsDeepLink]
+  ['plugins', handlePluginsDeepLink],
+  ['install-plugin', triggerPluginAction('install')],
+  ['configure-plugin', triggerPluginAction('configure')]
 ]);
 
 const handleDeepLink = url => {

--- a/main/utils/errors.js
+++ b/main/utils/errors.js
@@ -10,6 +10,7 @@ const showError = async (error, {title, reportToSentry} = {}) => {
 
   console.error(error);
   if (reportToSentry) {
+    // Imported here to avoid circular dependency
     const Sentry = require('./sentry');
     Sentry.captureException(ensuredError);
   }

--- a/main/utils/errors.js
+++ b/main/utils/errors.js
@@ -2,7 +2,6 @@
 
 const {dialog, clipboard} = require('electron');
 const ensureError = require('ensure-error');
-const Sentry = require('./sentry');
 const cleanStack = require('clean-stack');
 
 const showError = async (error, {title, reportToSentry} = {}) => {
@@ -11,6 +10,7 @@ const showError = async (error, {title, reportToSentry} = {}) => {
 
   console.error(error);
   if (reportToSentry) {
+    const Sentry = require('./sentry');
     Sentry.captureException(ensuredError);
   }
 

--- a/renderer/components/preferences/categories/plugins/index.js
+++ b/renderer/components/preferences/categories/plugins/index.js
@@ -64,7 +64,7 @@ class Plugins extends React.Component {
           </nav>
           <div className="tab-container">
             <div className="switcher"/>
-            <div className="tab">
+            <div className="tab" id="discover">
               {
                 npmError ? (
                   <EmptyTab
@@ -85,7 +85,7 @@ class Plugins extends React.Component {
                 )
               }
             </div>
-            <div className="tab">
+            <div className="tab" id="installed">
               {
                 pluginsInstalled.length === 0 ? (
                   <EmptyTab

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -33,11 +33,6 @@ export default class PreferencesContainer extends Container {
       isMounted: true
     });
 
-    if (this.state.target && pluginsInstalled.some(plugin => plugin.name === this.state.target.name)) {
-      this.openTarget(this.state.target);
-      this.setState({target: undefined});
-    }
-
     if (this.settings.store.recordAudio) {
       this.getAudioDevices();
     }

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -89,7 +89,7 @@ export default class PreferencesContainer extends Container {
           ],
           defaultId: 0,
           cancelId: 1,
-          message: `Do you want to install ${target.name}?`
+          message: `Do you want to install the “${target.name}” plugin?`
         });
 
         if (buttonIndex === 0) {

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -31,8 +31,6 @@ export default class PreferencesContainer extends Container {
       openOnStartup: this.remote.app.getLoginItemSettings().openAtLogin,
       pluginsInstalled,
       isMounted: true
-    }, () => {
-      console.log('done');
     });
 
     if (this.state.target && pluginsInstalled.some(plugin => plugin.name === this.state.target.name)) {
@@ -68,7 +66,6 @@ export default class PreferencesContainer extends Container {
   }
 
   scrollIntoView = (tabId, pluginId) => {
-    console.log(tabId, pluginId);
     const tab = document.querySelector(`#${tabId}`);
     const plugin = tab.querySelector(`#${pluginId}`).parentElement;
     tab.scrollTo(0, plugin.offsetTop - tab.offsetTop);
@@ -78,7 +75,6 @@ export default class PreferencesContainer extends Container {
     const isInstalled = this.state.pluginsInstalled.some(plugin => plugin.name === target.name);
     const isFromNpm = this.state.pluginsFromNpm && this.state.pluginsFromNpm.some(plugin => plugin.name === target.name);
 
-    console.log('In here with', target, isInstalled, isFromNpm);
     if (target.action === 'install') {
       if (isInstalled) {
         this.scrollIntoView(this.state.tab, target.name);

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -61,9 +61,12 @@ export default class PreferencesContainer extends Container {
   }
 
   scrollIntoView = (tabId, pluginId) => {
-    const tab = document.querySelector(`#${tabId}`);
-    const plugin = tab.querySelector(`#${pluginId}`).parentElement;
-    tab.scrollTo(0, plugin.offsetTop - tab.offsetTop);
+    const plugin = document.querySelector(`#${tabId} #${pluginId}`).parentElement;
+    plugin.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+      inline: 'nearest'
+    });
   }
 
   openTarget = target => {
@@ -77,7 +80,21 @@ export default class PreferencesContainer extends Container {
       } else if (isFromNpm) {
         this.scrollIntoView('discover', target.name);
         this.setState({category: 'plugins', tab: 'discover'});
-        this.install(target.name);
+
+        const buttonIndex = this.remote.dialog.showMessageBoxSync(this.remote.getCurrentWindow(), {
+          type: 'question',
+          buttons: [
+            'Install',
+            'Cancel'
+          ],
+          defaultId: 0,
+          cancelId: 1,
+          message: `Do you want to install ${target.name}?`
+        });
+
+        if (buttonIndex === 0) {
+          this.install(target.name);
+        }
       } else {
         this.setState({category: 'plugins'});
       }


### PR DESCRIPTION
Adds ability to install/configure plugins via the following deep links:

`kap://install-plugin/{plugin name}`

Pops up preferences on the discover tab scrolls to the plugin, and triggers an installation. If it's already installed, it just scrolls to it.

`kap://configure-plugin/{plugin name}`

Pops up preferences, scrolls to the plugin and opens the config window

Also fixed some small issues, including a circular dependency I introduced a few PRs ago which was causing the built app not to run

To test this build, after you've downloaded and installed it, click here:

[![Install](https://getkapco-git-add-deep-link-assets.wulkano1.vercel.app/button/install)](https://getkapco-git-add-deep-link-assets.wulkano1.vercel.app/deep-link/install/kap-recording-time)

And then to configure:

kap://configure-plugin/kap-record-time

EDIT:
seems like GH doesn't support links with custom schemes, so copy-paste the links underneath for now. We can probably create a small lamda to re-route to the deep link

~These badges are some examples I generated with shield.io, but we can make our own custom images, host them under `https://getkap.co/buttons/{install|configure}` so we can add buttons like that to the plugin readmes~

https://github.com/wulkano/getkap.co/pull/36

