### PR TITLE
Fix select config bug

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
   </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
       "entitlements": "./build/entitlements.mac.inherit.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Kap needs access to the microphone to be able to record audio for screen recordings.",
+        "NSCameraUsageDescription": "A Kap plugin wants to use the camera.",
         "NSUserNotificationAlertStyle": "alert",
         "CFBundleDocumentTypes": [
           {

--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -20,6 +20,13 @@ const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
 
   if (type === 'select') {
     const options = schema.enum.map(value => ({label: value, value}));
+
+    if (!options.some(option => option.value === value)) {
+      const newValue = options[0] && options[0].value;
+      onChange(name, newValue);
+      return <Select full tabIndex={0} options={options} selected={newValue} onSelect={value => onChange(name, value)}/>;
+    }
+
     return <Select full tabIndex={0} options={options} selected={value} onSelect={value => onChange(name, value)}/>;
   }
 


### PR DESCRIPTION
Fixes a small bug where if the current value is not in the available options, it'll show an ugly react error. This way, it'll default to the first option.

This happens semi-often in a new plugin I'm working on. Only reason I came across it

Also it adds permissions and string for accessing the camera, also needed for the same plugin. Followed the same generic message type as apps like iTerm use.