### PR TITLE
Add sentry releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
           path: dist/Kap.dmg
   sentry-release:
     docker:
-      - image: circleci/node:4.8.2
+      - image: circleci/node:lts
     environment:
       SENTRY_ORG: wulkano-l0
       SENTRY_PROJECT: kap
     steps:
       - checkout
       - run: yarn -v
-      - run: yarn -s run 'sentry-version'
+      - run: yarn run -s sentry-version
       - run: export SENTRY_RELEASE=$(yarn -s run 'sentry-version')
       - run: echo $SENTRY_RELEASE
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,13 @@ jobs:
       SENTRY_PROJECT: kap
     steps:
       - checkout
-      - run: yarn run -s sentry-version
-      - run: export SENTRY_RELEASE=$(yarn run -s sentry-version)
+      - run: yarn -v
+      - run: yarn -s run 'sentry-version'
+      - run: export SENTRY_RELEASE=$(yarn -s run 'sentry-version')
       - run: echo $SENTRY_RELEASE
       - run: |
           curl -sL https://sentry.io/get-cli/ | bash
-          export SENTRY_RELEASE=$(yarn run -s sentry-version)
+          export SENTRY_RELEASE=$(yarn -s run 'sentry-version')
           sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
           sentry-cli releases set-commits --auto $SENTRY_RELEASE
           sentry-cli releases finalize $SENTRY_RELEASE
@@ -37,9 +38,11 @@ workflows:
           filters:
             tags:
               only: /.*/ # Force CircleCI to build on tags
+            branches:
+              ignore: /.*/
       - sentry-release:
-          requires:
-            - build
+          # requires:
+          #   - build
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,21 @@ jobs:
       - run: mv dist/*.dmg dist/Kap.dmg
       - store_artifacts:
           path: dist/Kap.dmg
+  sentry-release:
+    docker:
+      - image: circleci/node:4.8.2
+    environment:
+      SENTRY_ORG: wulkano-l0
+      SENTRY_PROJECT: kap
+    steps:
+      - checkout
+      - run: |
+          curl -sL https://sentry.io/get-cli/ | bash
+          export SENTRY_RELEASE=$(yarn run -s sentry-version)
+          sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+          sentry-cli releases set-commits --auto $SENTRY_RELEASE
+          sentry-cli releases finalize $SENTRY_RELEASE
+
 workflows:
   version: 2
   build:
@@ -19,3 +34,11 @@ workflows:
           filters:
             tags:
               only: /.*/ # Force CircleCI to build on tags
+      - sentry-release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,9 @@ jobs:
       SENTRY_PROJECT: kap
     steps:
       - checkout
-      - run: yarn -v
-      - run: yarn run -s sentry-version
-      - run: export SENTRY_RELEASE=$(yarn -s run 'sentry-version')
-      - run: echo $SENTRY_RELEASE
       - run: |
           curl -sL https://sentry.io/get-cli/ | bash
-          export SENTRY_RELEASE=$(yarn -s run 'sentry-version')
+          export SENTRY_RELEASE=$(yarn run -s sentry-version)
           sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
           sentry-cli releases set-commits --auto $SENTRY_RELEASE
           sentry-cli releases finalize $SENTRY_RELEASE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
       SENTRY_PROJECT: kap
     steps:
       - checkout
+      - run: yarn run -s sentry-version
+      - run: export SENTRY_RELEASE=$(yarn run -s sentry-version)
+      - run: echo $SENTRY_RELEASE
       - run: |
           curl -sL https://sentry.io/get-cli/ | bash
           export SENTRY_RELEASE=$(yarn run -s sentry-version)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,11 @@ workflows:
           filters:
             tags:
               only: /.*/ # Force CircleCI to build on tags
-            branches:
-              ignore: /.*/
       - sentry-release:
-          # requires:
-          #   - build
+          requires:
+            - build
           filters:
             tags:
               only: /^v.*/
-            # branches:
-            #   ignore: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,5 +40,5 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              ignore: /.*/
+            # branches:
+            #   ignore: /.*/

--- a/main/utils/sentry.js
+++ b/main/utils/sentry.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const {app} = require('electron');
 const {is} = require('electron-util');
 const Sentry = require('@sentry/electron');
 const settings = require('../common/settings');
@@ -9,7 +10,11 @@ const SENTRY_PUBLIC_DSN = 'https://2dffdbd619f34418817f4db3309299ce@sentry.io/25
 const isSentryEnabled = !is.development && settings.get('allowAnalytics');
 
 if (isSentryEnabled) {
-  Sentry.init({dsn: SENTRY_PUBLIC_DSN});
+  const release = `${app.name}@${app.getVersion()}`.toLowerCase();
+  Sentry.init({
+    dsn: SENTRY_PUBLIC_DSN,
+    release
+  });
 }
 
 module.exports = Sentry;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "next build renderer && next export renderer",
     "dist": "npm run build && electron-builder",
     "pack": "npm run build && electron-builder --dir",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "sentry-version": "echo \"$npm_package_name@$npm_package_version\""
   },
   "bundle": {
     "name": "Kap"

--- a/renderer/pages/_app.js
+++ b/renderer/pages/_app.js
@@ -55,7 +55,8 @@ export default class Kap extends App {
       this.systemPreferences = api.systemPreferences;
 
       if (!is.development && settings.get('allowAnalytics')) {
-        Sentry.init({dsn: SENTRY_PUBLIC_DSN});
+        const release = `${api.app.name}@${api.app.getVersion()}`.toLowerCase();
+        Sentry.init({dsn: SENTRY_PUBLIC_DSN, release});
       }
 
       this.darkMode = darkMode;


### PR DESCRIPTION
Adds sentry releases. This should help us get better view into what commit fixed/caused issues.

Releases will be in the format of `kap@3.2.0`

Required env vars have been added to CircleCI, but I haven't tested it. I might run it a few times to make sure it works