### PR TITLE
Improve setting a global keyboard shortcut

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -349,10 +349,12 @@ const config = {
 
 #### `keyboardShortcut`
 
+[List of possible values](https://www.electronjs.org/docs/api/accelerator)
+
 ```js
 const config = {
-  shortcut: {
-    title: 'Trigger Shortcut',
+  keyboardShortcut: {
+    title: 'Toggle Unicorn Mode',
     customType: 'keyboardShortcut',
     required: true,
     default: 'Command+Shift+5'
@@ -364,7 +366,7 @@ const config = {
 electron.globalShortcut.register(config.get('shortcut'), () => { /* ... */ });
 ```
 
-**Note:** Kap will not register any action for the accelerator. That is up to the plugin implementation.
+**Note:** Kap will not register any action for the keyboard shortcut. That is up to the plugin implementation.
 
 ## General APIs
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -347,13 +347,13 @@ const config = {
 
 <img src="../media/plugins/hexColor.png" width="319">
 
-#### `accelerator`
+#### `keyboardShortcut`
 
 ```js
 const config = {
   shortcut: {
     title: 'Trigger Shortcut',
-    customType: 'accelerator',
+    customType: 'keyboardShortcut',
     required: true,
     default: 'Command+Shift+5'
   }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -347,6 +347,25 @@ const config = {
 
 <img src="../media/plugins/hexColor.png" width="319">
 
+#### `accelerator`
+
+```js
+const config = {
+  shortcut: {
+    title: 'Trigger Shortcut',
+    customType: 'accelerator',
+    required: true,
+    default: 'Command+Shift+5'
+  }
+};
+
+// Later
+
+electron.globalShortcut.register(config.get('shortcut'), () => { /* ... */ });
+```
+
+**Note:** Kap will not register any action for the accelerator. That is up to the plugin implementation.
+
 ## General APIs
 
 Every type of plugin and service can additionally export the following:

--- a/main/common/plugins.js
+++ b/main/common/plugins.js
@@ -27,7 +27,6 @@ class Plugins {
     this.yarnBin = path.join(__dirname, '../../node_modules/yarn/bin/yarn.js');
     this._makePluginsDir();
     this.appVersion = app.getVersion();
-    this.refreshRecordPluginServices();
   }
 
   setUpdateExportOptions(updateExportOptions) {

--- a/main/common/settings.js
+++ b/main/common/settings.js
@@ -93,7 +93,8 @@ const store = new Store({
     },
     shortcuts: {
       type: 'object',
-      properties: Object.keys(shortcuts).reduce((acc, key) => ({...acc, [key]: shortcutSchema}), {})
+      properties: Object.keys(shortcuts).reduce((acc, key) => ({...acc, [key]: shortcutSchema}), {}),
+      default: {}
     }
   }
 });

--- a/main/common/settings.js
+++ b/main/common/settings.js
@@ -9,7 +9,7 @@ const {getAudioDevices, getDefaultInputDevice} = require('../utils/devices');
 const shortcutToAccelerator = require('../utils/shortcut-to-accelerator');
 
 const shortcuts = {
-  triggerCropper: 'Trigger Kap'
+  triggerCropper: 'Toggle Kap'
 };
 
 const shortcutSchema = {
@@ -101,11 +101,13 @@ const store = new Store({
 module.exports = store;
 module.exports.shortcuts = shortcuts;
 
+// TODO: Remove this when we feel like everyone has migrated
 if (store.has('recordKeyboardShortcut')) {
   store.set('enableShortcuts', store.get('recordKeyboardShortcut'));
   store.delete('recordKeyboardShortcut');
 }
 
+// TODO: Remove this when we feel like everyone has migrated
 if (store.has('cropperShortcut')) {
   store.set('shortcuts.triggerCropper', shortcutToAccelerator(store.get('cropperShortcut')));
   store.delete('cropperShortcut');

--- a/main/common/settings.js
+++ b/main/common/settings.js
@@ -6,6 +6,16 @@ const Store = require('electron-store');
 const {defaultInputDeviceId} = require('./constants');
 const {hasMicrophoneAccess} = require('./system-permissions');
 const {getAudioDevices, getDefaultInputDevice} = require('../utils/devices');
+const shortcutToAccelerator = require('../utils/shortcut-to-accelerator');
+
+const shortcuts = {
+  triggerCropper: 'Trigger Kap'
+};
+
+const shortcutSchema = {
+  type: 'string',
+  default: ''
+};
 
 const store = new Store({
   schema: {
@@ -76,11 +86,30 @@ const store = new Store({
     lossyCompression: {
       type: 'boolean',
       default: false
+    },
+    enableShortcuts: {
+      type: 'boolean',
+      default: true
+    },
+    shortcuts: {
+      type: 'object',
+      properties: Object.keys(shortcuts).reduce((acc, key) => ({...acc, [key]: shortcutSchema}), {})
     }
   }
 });
 
 module.exports = store;
+module.exports.shortcuts = shortcuts;
+
+if (store.has('recordKeyboardShortcut')) {
+  store.set('enableShortcuts', store.get('recordKeyboardShortcut'));
+  store.delete('recordKeyboardShortcut');
+}
+
+if (store.has('cropperShortcut')) {
+  store.set('shortcuts.triggerCropper', shortcutToAccelerator(store.get('cropperShortcut')));
+  store.delete('cropperShortcut');
+}
 
 store.set('cropper', {});
 store.set('actionBar', {});

--- a/main/index.js
+++ b/main/index.js
@@ -7,22 +7,23 @@ const log = require('electron-log');
 const {autoUpdater} = require('electron-updater');
 const toMilliseconds = require('@sindresorhus/to-milliseconds');
 
+const settings = require('./common/settings');
+
+require('./utils/sentry');
+require('./utils/errors').setupErrorHandling();
+
 const {initializeTray} = require('./tray');
-const plugins = require('./common/plugins');
 const {initializeAnalytics} = require('./common/analytics');
 const initializeExportList = require('./export-list');
 const {openCropperWindow, isCropperOpen, closeAllCroppers} = require('./cropper');
 const {track} = require('./common/analytics');
+const plugins = require('./common/plugins');
 const {initializeGlobalAccelerators} = require('./global-accelerators');
 const {setApplicationMenu} = require('./menus');
 const openFiles = require('./utils/open-files');
 const {initializeExportOptions} = require('./export-options');
-const settings = require('./common/settings');
 const {hasMicrophoneAccess, ensureScreenCapturePermissions} = require('./common/system-permissions');
 const {handleDeepLink} = require('./utils/deep-linking');
-
-require('./utils/sentry');
-require('./utils/errors').setupErrorHandling();
 
 const filesToOpen = [];
 
@@ -40,6 +41,7 @@ app.on('open-file', (event, path) => {
 });
 
 const initializePlugins = async () => {
+  plugins.refreshRecordPluginServices();
   if (!is.development) {
     try {
       await plugins.prune();
@@ -76,10 +78,10 @@ const checkForUpdates = () => {
   // Ensure the app is in the Applications folder
   enforceMacOSAppLocation();
 
+  await prepareNext('./renderer');
+
   // Ensure all plugins are up to date
   initializePlugins();
-
-  await prepareNext('./renderer');
 
   initializeAnalytics();
   initializeTray();

--- a/main/utils/accelerator-validator.js
+++ b/main/utils/accelerator-validator.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// The goal of this file is validating accelerator values we receive from the user
+// to make sure that they are can be used with the electron api https://www.electronjs.org/docs/api/accelerator
+
+// Also, this extracts the right accelerator from a keyboard event, checking the
+// location for numpad keys and special characters for when shift is pressed
+
 const modifiers = ['Command', 'Alt', 'Option', 'Shift', 'Cmd', 'Control', 'Ctrl'];
 
 const codes = [

--- a/main/utils/accelerator-validator.js
+++ b/main/utils/accelerator-validator.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const modifiers = ['Command', 'Alt', 'Option', 'Shift', 'Cmd', 'Control', 'Ctrl'];
+
+const codes = [
+  'Plus',
+  'Space',
+  'Tab',
+  'Capslock',
+  'Numlock',
+  'Scrolllock',
+  'Backspace',
+  'Delete',
+  'Insert',
+  'Return',
+  'Enter',
+  'Up',
+  'Down',
+  'Left',
+  'Right',
+  'PageUp',
+  'PageDown',
+  'Escape',
+  'Esc',
+  'VolumeUp',
+  'VolumeDown',
+  'VolumeMute',
+  'num0',
+  'num1',
+  'num2',
+  'num3',
+  'num4',
+  'num5',
+  'num6',
+  'num7',
+  'num8',
+  'num9',
+  'numdec',
+  'numadd',
+  'numsub',
+  'nummult',
+  'numdiv'
+];
+
+const keyCodeRegex = new RegExp('^([\\dA-Z~`!@#$%^&*()_+=.,<>?;:\'"\\-\\/\\\\\\[\\]\\{\\}\\|]|F([1-9]|1[\\d]|2[0-4])|' + codes.join('|') + ')$');
+
+const shiftKeyMap = new Map([
+  ['~', '`'],
+  ['!', '1'],
+  ['@', '2'],
+  ['#', '3'],
+  ['$', '4'],
+  ['%', '5'],
+  ['^', '6'],
+  ['&', '7'],
+  ['*', '8'],
+  ['(', '9'],
+  [')', '0'],
+  ['_', '-'],
+  ['+', '='],
+  ['{', '['],
+  ['}', ']'],
+  ['|', '\\'],
+  [':', ';'],
+  ['"', '\''],
+  ['<', ','],
+  ['>', '.'],
+  ['?', '/']
+]);
+
+const numpadKeyMap = new Map([
+  ['0', 'num0'],
+  ['1', 'num1'],
+  ['2', 'num2'],
+  ['3', 'num3'],
+  ['4', 'num4'],
+  ['5', 'num5'],
+  ['6', 'num6'],
+  ['7', 'num7'],
+  ['8', 'num8'],
+  ['9', 'num9'],
+  ['.', 'numdec'],
+  ['+', 'numadd'],
+  ['-', 'numsub'],
+  ['*', 'nummult'],
+  ['/', 'numdiv']
+]);
+
+const namedKeyCodeMap = new Map([
+  [' ', 'Space'],
+  ['CapsLock', 'Capslock'],
+  ['ArrowUp', 'Up'],
+  ['ArrowDown', 'Down'],
+  ['ArrowLeft', 'Left'],
+  ['ArrowRight', 'Right'],
+  ['Clear', 'Numlock']
+]);
+
+const checkAccelerator = accelerator => {
+  if (!accelerator) {
+    return true;
+  }
+
+  const parts = accelerator.split('+');
+
+  if (parts.length < 2) {
+    return false;
+  }
+
+  if (!keyCodeRegex.test(parts[parts.length - 1])) {
+    return false;
+  }
+
+  const metaKeys = parts.slice(0, -1);
+  return metaKeys.every(part => modifiers.includes(part)) && metaKeys.some(part => part !== 'Shift');
+};
+
+const eventKeyToAccelerator = (key, location) => {
+  if (location === 3) {
+    return numpadKeyMap.get(key);
+  }
+
+  return namedKeyCodeMap.get(key) || shiftKeyMap.get(key) || key.toUpperCase();
+};
+
+module.exports = {
+  checkAccelerator,
+  eventKeyToAccelerator
+};

--- a/main/utils/ajv.js
+++ b/main/utils/ajv.js
@@ -7,8 +7,15 @@ const hexColorValidator = () => {
   };
 };
 
+const acceleratorValidator = () => {
+  return {
+    type: 'string'
+  };
+};
+
 const validators = new Map([
-  ['hexColor', hexColorValidator]
+  ['hexColor', hexColorValidator],
+  ['accelerator', acceleratorValidator]
 ]);
 
 class CustomAjv extends Ajv {

--- a/main/utils/ajv.js
+++ b/main/utils/ajv.js
@@ -7,7 +7,7 @@ const hexColorValidator = () => {
   };
 };
 
-const acceleratorValidator = () => {
+const keyboardShortcutValidator = () => {
   return {
     type: 'string'
   };
@@ -15,7 +15,7 @@ const acceleratorValidator = () => {
 
 const validators = new Map([
   ['hexColor', hexColorValidator],
-  ['accelerator', acceleratorValidator]
+  ['keyboardShortcut', keyboardShortcutValidator]
 ]);
 
 class CustomAjv extends Ajv {

--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -15,7 +15,7 @@ const horizontalTypes = [
 ];
 
 const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
-  if (type === 'accelerator') {
+  if (type === 'keyboardShortcut') {
     return (
       <div>
         <ShortcutInput

--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -18,14 +18,10 @@ const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
   if (type === 'keyboardShortcut') {
     return (
       <div>
-        <ShortcutInput
-          shortcut={value} onChange={value => {
-            console.log(name, value);
-            onChange(name, value);
-          }}/>
+        <ShortcutInput tabIndex={0} shortcut={value} onChange={value => onChange(name, value)}/>
         <style jsx>{`
           div {
-
+            margin-top: 8px;
           }
         `}</style>
       </div>

--- a/renderer/components/config/tab.js
+++ b/renderer/components/config/tab.js
@@ -7,6 +7,7 @@ import Select from '../preferences/item/select';
 import Switch from '../preferences/item/switch';
 import ColorPicker from '../preferences/item/color-picker';
 import {OpenOnGithubIcon, OpenConfigIcon} from '../../vectors';
+import ShortcutInput from '../preferences/shortcut-input';
 
 const horizontalTypes = [
   'boolean',
@@ -14,6 +15,23 @@ const horizontalTypes = [
 ];
 
 const ConfigInput = ({name, type, schema, value, onChange, hasErrors}) => {
+  if (type === 'accelerator') {
+    return (
+      <div>
+        <ShortcutInput
+          shortcut={value} onChange={value => {
+            console.log(name, value);
+            onChange(name, value);
+          }}/>
+        <style jsx>{`
+          div {
+
+          }
+        `}</style>
+      </div>
+    );
+  }
+
   if (type === 'hexColor') {
     return <ColorPicker value={value} name={name} hasErrors={hasErrors} onChange={value => onChange(name, value)}/>;
   }

--- a/renderer/components/preferences/categories/general.js
+++ b/renderer/components/preferences/categories/general.js
@@ -109,6 +109,7 @@ class General extends React.Component {
           parentItem
           title="Keyboard shortcuts"
           subtitle="Toggle and customise keyboard shortcuts"
+          help="You can paste any valid Electron accelerator string like Command+Shift+5"
         >
           <Switch tabIndex={tabIndex} checked={enableShortcuts} onClick={toggleShortcuts}/>
         </Item>

--- a/renderer/components/preferences/categories/general.js
+++ b/renderer/components/preferences/categories/general.js
@@ -40,7 +40,7 @@ class General extends React.Component {
       showCursor,
       highlightClicks,
       record60fps,
-      recordKeyboardShortcut,
+      enableShortcuts,
       loopExports,
       toggleSetting,
       toggleRecordAudio,
@@ -50,11 +50,12 @@ class General extends React.Component {
       recordAudio,
       pickKapturesDir,
       setOpenOnStartup,
-      cropperShortcut,
       updateShortcut,
       toggleShortcuts,
       category,
-      lossyCompression
+      lossyCompression,
+      shortcuts,
+      shortcutMap
     } = this.props;
 
     const {showCursorSupported} = this.state;
@@ -72,54 +73,55 @@ class General extends React.Component {
       <Category>
         {
           showCursorSupported &&
-            <Item
-              key="showCursor"
-              parentItem
-              title="Show cursor"
-              subtitle="Display the mouse cursor in your Kaptures"
-            >
-              <Switch
-                tabIndex={tabIndex}
-                checked={showCursor}
-                onClick={
-                  () => {
-                    if (showCursor) {
-                      toggleSetting('highlightClicks', false);
-                    }
-
-                    toggleSetting('showCursor');
+          <Item
+            key="showCursor"
+            parentItem
+            title="Show cursor"
+            subtitle="Display the mouse cursor in your Kaptures"
+          >
+            <Switch
+              tabIndex={tabIndex}
+              checked={showCursor}
+              onClick={
+                () => {
+                  if (showCursor) {
+                    toggleSetting('highlightClicks', false);
                   }
-                }/>
-            </Item>
+
+                  toggleSetting('showCursor');
+                }
+              }/>
+          </Item>
         }
         {
           showCursorSupported &&
-            <Item key="highlightClicks" subtitle="Highlight clicks">
-              <Switch
-                tabIndex={tabIndex}
-                checked={highlightClicks}
-                disabled={!showCursor}
-                onClick={() => toggleSetting('highlightClicks')}
-              />
-            </Item>
+          <Item key="highlightClicks" subtitle="Highlight clicks">
+            <Switch
+              tabIndex={tabIndex}
+              checked={highlightClicks}
+              disabled={!showCursor}
+              onClick={() => toggleSetting('highlightClicks')}
+            />
+          </Item>
         }
         <Item
-          key="recordKeyboardShortcut"
+          key="enableShortcuts"
           parentItem
           title="Keyboard shortcuts"
           subtitle="Toggle and customise keyboard shortcuts"
         >
-          <Switch tabIndex={tabIndex} checked={recordKeyboardShortcut} onClick={toggleShortcuts}/>
+          <Switch tabIndex={tabIndex} checked={enableShortcuts} onClick={toggleShortcuts}/>
         </Item>
         {
-          recordKeyboardShortcut &&
-            <Item key="cropperShortcut" subtitle="Trigger Kap">
+          enableShortcuts && Object.entries(shortcutMap).map(([key, title]) => (
+            <Item key={key} subtitle={title}>
               <ShortcutInput
-                shortcut={cropperShortcut}
+                shortcut={shortcuts[key]}
                 tabIndex={tabIndex}
-                onChange={shortcut => updateShortcut('cropperShortcut', shortcut)}
+                onChange={shortcut => updateShortcut(key, shortcut)}
               />
             </Item>
+          ))
         }
         <Item
           key="loopExports"
@@ -141,15 +143,15 @@ class General extends React.Component {
         </Item>
         {
           recordAudio &&
-            <Item key="audioInputDeviceId" subtitle="Select input device">
-              <Select
-                tabIndex={tabIndex}
-                options={devices}
-                selected={audioInputDeviceId}
-                placeholder="Select Device"
-                noOptionsMessage="No input devices"
-                onSelect={setAudioInputDeviceId}/>
-            </Item>
+          <Item key="audioInputDeviceId" subtitle="Select input device">
+            <Select
+              tabIndex={tabIndex}
+              options={devices}
+              selected={audioInputDeviceId}
+              placeholder="Select Device"
+              noOptionsMessage="No input devices"
+              onSelect={setAudioInputDeviceId}/>
+          </Item>
         }
         <Item
           key="record60fps"
@@ -206,7 +208,7 @@ General.propTypes = {
   showCursor: PropTypes.bool,
   highlightClicks: PropTypes.bool,
   record60fps: PropTypes.bool,
-  recordKeyboardShortcut: PropTypes.bool,
+  enableShortcuts: PropTypes.bool,
   toggleSetting: PropTypes.elementType.isRequired,
   toggleRecordAudio: PropTypes.elementType.isRequired,
   audioInputDeviceId: PropTypes.string,
@@ -222,13 +224,8 @@ General.propTypes = {
   updateShortcut: PropTypes.elementType.isRequired,
   toggleShortcuts: PropTypes.elementType.isRequired,
   category: PropTypes.string,
-  cropperShortcut: PropTypes.shape({
-    metaKey: PropTypes.bool.isRequired,
-    altKey: PropTypes.bool.isRequired,
-    ctrlKey: PropTypes.bool.isRequired,
-    shiftKey: PropTypes.bool.isRequired,
-    character: PropTypes.string.isRequired
-  }),
+  shortcutMap: PropTypes.object,
+  shortcuts: PropTypes.object,
   lossyCompression: PropTypes.bool
 };
 
@@ -239,31 +236,33 @@ export default connect(
     highlightClicks,
     record60fps,
     recordAudio,
-    recordKeyboardShortcut,
+    enableShortcuts,
     audioInputDeviceId,
     audioDevices,
     kapturesDir,
     openOnStartup,
     allowAnalytics,
     loopExports,
-    cropperShortcut,
     category,
-    lossyCompression
+    lossyCompression,
+    shortcuts,
+    shortcutMap
   }) => ({
     showCursor,
     highlightClicks,
     record60fps,
     recordAudio,
-    recordKeyboardShortcut,
+    enableShortcuts,
     audioInputDeviceId,
     audioDevices,
     kapturesDir,
     openOnStartup,
     allowAnalytics,
     loopExports,
-    cropperShortcut,
     category,
-    lossyCompression
+    lossyCompression,
+    shortcuts,
+    shortcutMap
   }),
   ({
     toggleSetting,

--- a/renderer/components/preferences/item/index.js
+++ b/renderer/components/preferences/item/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Linkify from 'react-linkify';
+import {HelpIcon} from '../../../vectors';
 
 export const Link = ({href, children}) => (
   <span onClick={() => electron.shell.openExternal(href)}>
@@ -48,7 +49,8 @@ class Item extends React.Component {
       onClick,
       last,
       parentItem,
-      small
+      small,
+      help
     } = this.props;
 
     const subtitleArray = Array.isArray(subtitle) ? subtitle : [subtitle];
@@ -62,7 +64,16 @@ class Item extends React.Component {
         <div className="item" id={id}>
           {warning}
           <div className="content">
-            <div className={className}>{title}</div>
+            <div className={className}>
+              {title}
+              {
+                help && (
+                  <div title={help}>
+                    <HelpIcon hoverFill="var(--icon-color)" size="16px"/>
+                  </div>
+                )
+              }
+            </div>
             <div className={subtitleClassName} title={tooltip} onClick={onSubtitleClick}>
               { subtitleArray.map(s => <div key={s}><Linkify component={Link}>{s}</Linkify></div>) }
             </div>
@@ -101,6 +112,11 @@ class Item extends React.Component {
             line-height: 1.6rem;
             font-weight: 500;
             color: var(--title-color);
+            display: flex;
+          }
+
+          .title div {
+            margin-left: 8px;
           }
 
           .content {
@@ -165,6 +181,7 @@ class Item extends React.Component {
 }
 
 Item.propTypes = {
+  help: PropTypes.string,
   id: PropTypes.string,
   title: PropTypes.oneOfType([
     PropTypes.string,

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -87,7 +87,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
   };
 
   const handleKeyDown = event => {
-    const {metaKey, altKey, ctrlKey, shiftKey, key, location, which} = event;
+    const {metaKey, altKey, ctrlKey, shiftKey, key, location, keyCode} = event;
     const metaKeys = [
       metaKey && 'Command',
       altKey && 'Alt',
@@ -117,7 +117,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
       return;
     }
 
-    const mappedKey = (which > 47 && which < 58) || (which > 64 && which < 91) ? String.fromCharCode(which) : key;
+    const mappedKey = (keyCode > 47 && keyCode < 58) || (keyCode > 64 && keyCode < 91) ? String.fromCharCode(keyCode) : key;
 
     const keys = [...metaKeys, eventKeyToAccelerator(mappedKey, location)];
     const accelerator = keys.join('+');

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -87,7 +87,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
   };
 
   const handleKeyDown = event => {
-    const {metaKey, altKey, ctrlKey, shiftKey, key, location} = event;
+    const {metaKey, altKey, ctrlKey, shiftKey, key, location, which} = event;
     const metaKeys = [
       metaKey && 'Command',
       altKey && 'Alt',
@@ -107,7 +107,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
     }
 
     // Handled by the `onPaste` event
-    if (metaKeys.length === 1 && metaKeys && key.toUpperCase() === 'V') {
+    if (metaKeys.length === 1 && metaKey && key.toUpperCase() === 'V') {
       return;
     }
 
@@ -117,7 +117,9 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
       return;
     }
 
-    const keys = [...metaKeys, eventKeyToAccelerator(key, location)];
+    const mappedKey = (which > 47 && which < 58) || (which > 64 && which < 91) ? String.fromCharCode(which) : key;
+
+    const keys = [...metaKeys, eventKeyToAccelerator(mappedKey, location)];
     const accelerator = keys.join('+');
     setIsEditing(false);
     if (checkAccelerator(accelerator)) {

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {useRef, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {shake} from '../../utils/inputs';
+import {checkAccelerator, eventKeyToAccelerator} from '../../../main/utils/accelerator-validator';
 
 const Key = ({children}) => (
   <span>
@@ -18,7 +19,7 @@ const Key = ({children}) => (
       border-radius: 4px 4px 4px 4px;
       border: 1px solid var(--shortcut-key-border);
       height: 20px;
-      width: 20px;
+      padding: 0 5px;
       margin-right: 2px;
       box-sizing: border-box;
       box-shadow: var(--shortcut-box-shadow);
@@ -35,176 +36,201 @@ Key.propTypes = {
   ]).isRequired
 };
 
-export default class ShortcutInput extends React.Component {
-  state = {
-    metaKey: (this.props.shortcut && this.props.shortcut.metaKey) || false,
-    altKey: (this.props.shortcut && this.props.shortcut.altKey) || false,
-    ctrlKey: (this.props.shortcut && this.props.shortcut.ctrlKey) || false,
-    shiftKey: (this.props.shortcut && this.props.shortcut.shiftKey) || false,
-    character: (this.props.shortcut && this.props.shortcut.character) || ''
-  }
+const metaCharacters = new Map([
+  ['Command', '⌘'],
+  ['Alt', '⌥'],
+  ['Option', '⌥'],
+  ['Shift', '⇧'],
+  ['Cmd', '⌘'],
+  ['Control', '⌃'],
+  ['Ctrl', '⌃']
+]);
 
-  handleKeyDown = event => {
-    if (event.which === 9) {
-      return;
-    }
+const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
+  const [keys, setKeys] = useState(shortcut.split('+').filter(Boolean));
+  const [isEditing, setIsEditing] = useState(false);
+  const boxRef = useRef();
+  const inputRef = useRef();
 
-    event.preventDefault();
-    const {metaKey, altKey, ctrlKey, shiftKey} = event;
-    const INVALID_KEYS = [17, 16, 91, 8, 18];
-    const character = INVALID_KEYS.includes(event.which) ? '' : String.fromCharCode(event.which);
-    this.setState({metaKey, altKey, ctrlKey, shiftKey, character});
-  }
+  const resetKeys = () => setKeys(shortcut.split('+').filter(Boolean));
 
-  get isValid() {
-    const {metaKey, altKey, ctrlKey, shiftKey, character} = this.state;
+  useEffect(() => {
+    resetKeys();
+  }, [shortcut]);
 
-    if (![metaKey, altKey, ctrlKey, shiftKey].includes(true)) {
-      return false;
-    }
+  const keysToRender = keys.map(key => {
+    return metaCharacters.get(key) || key;
+  });
 
-    if (character.length === 0) {
-      return false;
-    }
+  const clearShortcut = () => {
+    setKeys([]);
+    onChange(undefined);
+  };
 
-    return true;
-  }
-
-  get isEmpty() {
-    const {metaKey, altKey, ctrlKey, shiftKey, character} = this.state;
-
-    return ![metaKey, altKey, ctrlKey, shiftKey, character].some(Boolean);
-  }
-
-  store = event => {
-    if (event.which === 9) {
-      return;
-    }
-
-    if (this.isValid) {
-      this.props.onChange(this.state);
-    } else {
-      shake(this.boxRef.current);
-    }
-  }
-
-  renderKeys = () => {
-    const {metaKey, altKey, ctrlKey, shiftKey, character} = this.state;
-    const keys = [
-      metaKey && '⌘',
-      altKey && '⌥',
-      ctrlKey && '⌃',
-      shiftKey && '⇧',
-      character
+  const cancel = event => {
+    const {metaKey, altKey, ctrlKey, shiftKey, key} = event;
+    const metaKeys = [
+      metaKey && 'Command',
+      altKey && 'Alt',
+      ctrlKey && 'Control',
+      shiftKey && 'Shift'
     ].filter(Boolean);
 
-    return keys.map(key => <Key key={key}>{key}</Key>);
-  }
-
-  clearShortcut = () => {
-    this.setState({metaKey: false, altKey: false, ctrlKey: false, shiftKey: false, character: ''});
-    this.props.onChange(null);
-  }
-
-  handleBlur = () => {
-    if (!this.isValid) {
-      this.clearShortcut();
+    if (metaKeys.length > 0 && ['Shift', 'Control', 'Alt', 'Meta'].includes(key)) {
+      setKeys(metaKeys);
+      return;
     }
-  }
 
-  boxRef = React.createRef()
+    shake(boxRef.current);
+    resetKeys();
+    setIsEditing(false);
+  };
 
-  inputRef = React.createRef()
+  const handleKeyDown = event => {
+    const {metaKey, altKey, ctrlKey, shiftKey, key, location} = event;
+    const metaKeys = [
+      metaKey && 'Command',
+      altKey && 'Alt',
+      ctrlKey && 'Control',
+      shiftKey && 'Shift'
+    ].filter(Boolean);
 
-  render() {
-    const {tabIndex} = this.props;
-    const className = classNames('box', {invalid: !this.isEmpty && !this.isValid});
+    if (metaKeys.length === 0) {
+      if (key === 'Tab') {
+        return;
+      }
 
-    return (
-      <div className="shortcut-input">
-        <div ref={this.boxRef} className={className} onClick={() => this.inputRef.current.focus()}>
-          {this.renderKeys()}
-          <input
-            ref={this.inputRef}
-            tabIndex={tabIndex}
-            onKeyUp={this.store}
-            onKeyDown={this.handleKeyDown}
-            onBlur={this.handleBlur}
-          />
-        </div>
-        <button type="button" tabIndex={tabIndex} onClick={this.clearShortcut}>
-          <svg style={{width: '20px', height: '20px'}} viewBox="0 0 24 24">
-            <path fill="var(--icon-color)" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/>
-          </svg>
-        </button>
-        <style jsx>{`
-          .shortcut-input {
-            display: flex;
-            flex-direction: row;
-            align-items: stretch;
-            justify-content: stretch;
-          }
+      if (['Escape', 'Delete', 'Backspace'].includes(key)) {
+        clearShortcut();
+        return;
+      }
+    }
 
-          .box {
-            position: relative;
-            padding: 1px 1px;
-            background: var(--input-background-color);
-            border-radius: 3px;
-            border: 1px solid var(--input-border-color);
-            width: 96px;
-            cursor: text;
-            display: flex;
-            height: 24px;
-            box-sizing: border-box;
-          }
+    // Handled by the `onPaste` event
+    if (metaKeys.length === 1 && metaKeys && key.toUpperCase() === 'V') {
+      return;
+    }
 
-          .box:focus-within {
-            border-color: var(--input-focus-border-color);
-          }
+    if (['Shift', 'Control', 'Alt', 'Meta'].includes(key)) {
+      setKeys(metaKeys);
+      setIsEditing(true);
+      return;
+    }
 
-          input {
-            display: inline-block;
-            width: 1px;
-            outline: none !important;
-            border: none;
-            background: transparent;
-            color: var(--title-color);
-          }
+    const keys = [...metaKeys, eventKeyToAccelerator(key, location)];
+    const accelerator = keys.join('+');
+    setIsEditing(false);
+    if (checkAccelerator(accelerator)) {
+      setKeys(keys);
+      onChange(accelerator);
+    } else {
+      shake(boxRef.current);
+      resetKeys();
+    }
+  };
 
-          .invalid:focus-within {
-            border-color: red;
-          }
+  const paste = event => {
+    const text = (event.clipboardData || window.clipboardData).getData('text');
 
-          button {
-            display: inline-flex;
-            justify-content: center;
-            align-items: center;
-            background: var(--input-background-color);
-            border-radius: 3px 3px 3px 3px;
-            padding: 1px 3px;
-            border: 1px solid var(--input-border-color);
-            margin-left: 8px;
-            width: 24px;
-            height: 24px;
-            box-sizing: border-box;
-            outline: none;
-          }
+    setIsEditing(false);
+    if (checkAccelerator(text)) {
+      setKeys(text.split('+').filter(Boolean));
+      onChange(text);
+    } else {
+      shake(boxRef.current);
+      resetKeys();
+    }
+  };
 
-          button:focus {
-            border-color: var(--kap);
-          }
+  const className = classNames('box', {invalid: false});
 
-          button:hover {
-            --icon-color: var(--navigation-item-hover-color);
-          }
-        `}</style>
+  return (
+    <div className="shortcut-input">
+      <div ref={boxRef} className={className} onClick={() => inputRef.current.focus()}>
+        {keysToRender.map(key => <Key key={key}>{key}</Key>)}
+        <input
+          ref={inputRef}
+          tabIndex={tabIndex}
+          onKeyDown={handleKeyDown}
+          onKeyUp={isEditing ? cancel : undefined}
+          onBlur={isEditing ? cancel : undefined}
+          onPaste={paste}
+        />
       </div>
-    );
-  }
-}
+      <button type="button" tabIndex={tabIndex} onClick={clearShortcut}>
+        <svg style={{width: '20px', height: '20px'}} viewBox="0 0 24 24">
+          <path fill="var(--icon-color)" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/>
+        </svg>
+      </button>
+      <style jsx>{`
+        .shortcut-input {
+          display: flex;
+          flex-direction: row;
+          align-items: stretch;
+          justify-content: stretch;
+        }
+
+        .box {
+          position: relative;
+          padding: 1px 1px;
+          background: var(--input-background-color);
+          border-radius: 3px;
+          border: 1px solid var(--input-border-color);
+          width: 120px;
+          cursor: text;
+          display: flex;
+          height: 24px;
+          box-sizing: border-box;
+        }
+
+        .box:focus-within {
+          border-color: var(--input-focus-border-color);
+        }
+
+        input {
+          display: inline-block;
+          width: 1px;
+          outline: none !important;
+          border: none;
+          background: transparent;
+          color: var(--title-color);
+        }
+
+        .invalid:focus-within {
+          border-color: red;
+        }
+
+        button {
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          background: var(--input-background-color);
+          border-radius: 3px 3px 3px 3px;
+          padding: 1px 3px;
+          border: 1px solid var(--input-border-color);
+          margin-left: 8px;
+          width: 24px;
+          height: 24px;
+          box-sizing: border-box;
+          outline: none;
+        }
+
+        button:focus {
+          border-color: var(--kap);
+        }
+
+        button:hover {
+          --icon-color: var(--navigation-item-hover-color);
+        }
+      `}</style>
+    </div>
+  );
+};
 
 ShortcutInput.propTypes = {
-  shortcut: PropTypes.object,
+  shortcut: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   tabIndex: PropTypes.number.isRequired
 };
+
+export default ShortcutInput;

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -58,9 +58,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
     resetKeys();
   }, [shortcut]);
 
-  const keysToRender = keys.map(key => {
-    return metaCharacters.get(key) || key;
-  });
+  const keysToRender = keys.map(key => metaCharacters.get(key) || key);
 
   const clearShortcut = () => {
     setKeys([]);
@@ -87,6 +85,7 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
   };
 
   const handleKeyDown = event => {
+    // TODO: Use `code` instead of `keyCode` when this is released https://github.com/facebook/react/pull/18287
     const {metaKey, altKey, ctrlKey, shiftKey, key, location, keyCode} = event;
     const metaKeys = [
       metaKey && 'Command',

--- a/renderer/components/preferences/shortcut-input.js
+++ b/renderer/components/preferences/shortcut-input.js
@@ -3,6 +3,14 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {shake} from '../../utils/inputs';
 import {checkAccelerator, eventKeyToAccelerator} from '../../../main/utils/accelerator-validator';
+import {DropdownArrowIcon} from '../../vectors';
+
+const presets = [
+  'Command+Shift+3',
+  'Command+Shift+4',
+  'Command+Shift+5',
+  'Command+Shift+6'
+];
 
 const Key = ({children}) => (
   <span>
@@ -143,20 +151,41 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
     }
   };
 
+  const openMenu = () => {
+    const {Menu} = require('electron').remote;
+    const menu = Menu.buildFromTemplate(presets.map(accelerator => ({
+      label: accelerator.split('+').map(key => metaCharacters.get(key) || key).join(''),
+      click: () => {
+        onChange(accelerator);
+      }
+    })));
+
+    const {left, top} = boxRef.current.getBoundingClientRect();
+    menu.popup({
+      x: Math.round(left),
+      y: Math.round(top)
+    });
+  };
+
   const className = classNames('box', {invalid: false});
 
   return (
     <div className="shortcut-input">
       <div ref={boxRef} className={className} onClick={() => inputRef.current.focus()}>
-        {keysToRender.map(key => <Key key={key}>{key}</Key>)}
-        <input
-          ref={inputRef}
-          tabIndex={tabIndex}
-          onKeyDown={handleKeyDown}
-          onKeyUp={isEditing ? cancel : undefined}
-          onBlur={isEditing ? cancel : undefined}
-          onPaste={paste}
-        />
+        <div className="key-container">
+          {keysToRender.map(key => <Key key={key}>{key}</Key>)}
+          <input
+            ref={inputRef}
+            tabIndex={tabIndex}
+            onKeyDown={handleKeyDown}
+            onKeyUp={isEditing ? cancel : undefined}
+            onBlur={isEditing ? cancel : undefined}
+            onPaste={paste}
+          />
+        </div>
+        <div className="dropdown">
+          <DropdownArrowIcon onClick={openMenu}/>
+        </div>
       </div>
       <button type="button" tabIndex={tabIndex} onClick={clearShortcut}>
         <svg style={{width: '20px', height: '20px'}} viewBox="0 0 24 24">
@@ -171,17 +200,27 @@ const ShortcutInput = ({shortcut = '', onChange, tabIndex}) => {
           justify-content: stretch;
         }
 
+        .dropdown {
+          cursor: default;
+        }
+
         .box {
           position: relative;
           padding: 1px 1px;
           background: var(--input-background-color);
           border-radius: 3px;
           border: 1px solid var(--input-border-color);
-          width: 120px;
+          min-width: 96px;
           cursor: text;
           display: flex;
           height: 24px;
           box-sizing: border-box;
+          justify-content: space-between;
+          align-items: center;
+        }
+
+        .key-container {
+          display: flex;
         }
 
         .box:focus-within {

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -27,6 +27,7 @@ export default class PreferencesContainer extends Container {
     this.fetchFromNpm();
 
     this.setState({
+      shortcuts: {},
       ...this.settings.store,
       openOnStartup: this.remote.app.getLoginItemSettings().openAtLogin,
       pluginsInstalled,

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -30,7 +30,8 @@ export default class PreferencesContainer extends Container {
       ...this.settings.store,
       openOnStartup: this.remote.app.getLoginItemSettings().openAtLogin,
       pluginsInstalled,
-      isMounted: true
+      isMounted: true,
+      shortcutMap: this.settings.shortcuts
     });
 
     if (this.settings.store.recordAudio) {
@@ -235,7 +236,7 @@ export default class PreferencesContainer extends Container {
   }
 
   toggleShortcuts = async () => {
-    const setting = 'recordKeyboardShortcut';
+    const setting = 'enableShortcuts';
     const newValue = !this.state[setting];
     this.toggleSetting(setting, newValue);
     await ipc.callMain('toggle-shortcuts', {enabled: newValue});
@@ -244,7 +245,14 @@ export default class PreferencesContainer extends Container {
   updateShortcut = async (setting, shortcut) => {
     try {
       await ipc.callMain('update-shortcut', {setting, shortcut});
-      this.setState({[setting]: shortcut});
+      this.setState({
+        shortcuts: {
+          // TODO: Fix this ESLint violation
+          // eslint-disable-next-line react/no-access-state-in-setstate
+          ...this.state.shortcuts,
+          [setting]: shortcut
+        }
+      });
     } catch (error) {
       console.warn('Error updating shortcut', error);
     }

--- a/renderer/vectors/help.js
+++ b/renderer/vectors/help.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Svg from './svg';
+
+const HelpIcon = props => (
+  <Svg {...props}>
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 17h-2v-2h2v2zm2-7.8l-.8 1c-.8.7-1.2 1.3-1.2 2.8h-2v-.5a4 4 0 011.2-2.8l1.2-1.3c.4-.4.6-.9.6-1.4 0-1.1-.9-2-2-2s-2 .9-2 2H8a4 4 0 118 0c0 .9-.4 1.7-1 2.3z"/>
+  </Svg>
+);
+
+export default HelpIcon;

--- a/renderer/vectors/index.js
+++ b/renderer/vectors/index.js
@@ -22,6 +22,7 @@ import EditIcon from './edit';
 import ErrorIcon from './error';
 import OpenConfigIcon from './open-config';
 import OpenOnGithubIcon from './open-on-github';
+import HelpIcon from './help';
 
 export {
   ApplicationsIcon,
@@ -47,5 +48,6 @@ export {
   EditIcon,
   ErrorIcon,
   OpenConfigIcon,
-  OpenOnGithubIcon
+  OpenOnGithubIcon,
+  HelpIcon
 };


### PR DESCRIPTION
Closes #868 

So, this rewrites our handling of accelerators a bit. First, it allows for a bit of better handling of the input (where some keys wouldn't work or show weird characters).

Second, it supports pasting a custom accelerator for edge cases like `Command+Shift+5` where even though we are able to register it, we can't receive it through our input (since the system won't trigger the `mouseDown` event)

Finally, it adds support for `accelerator` custom type for plugins config.

For #868, the only workaround I was able to think of (other than manually editing the `config.json` file), is that you can copy the `Command+Shift+5` text, and then paste in the input.