### PR TITLE
Add AV1 support

### DIFF
--- a/main/common/constants.js
+++ b/main/common/constants.js
@@ -6,9 +6,7 @@ const formatExtensions = new Map([
   ['av1', 'mp4']
 ]);
 
-const getFormatExtension = format => {
-  return formatExtensions.get(format) || format;
-};
+const getFormatExtension = format => formatExtensions.get(format) || format;
 
 module.exports = {
   supportedVideoExtensions,

--- a/main/common/constants.js
+++ b/main/common/constants.js
@@ -2,7 +2,16 @@
 
 const supportedVideoExtensions = ['mp4', 'mov', 'm4v'];
 
+const formatExtensions = new Map([
+  ['av1', 'mp4']
+]);
+
+const getFormatExtension = format => {
+  return formatExtensions.get(format) || format;
+};
+
 module.exports = {
   supportedVideoExtensions,
+  getFormatExtension,
   defaultInputDeviceId: 'SYSTEM_DEFAULT'
 };

--- a/main/convert.js
+++ b/main/convert.js
@@ -23,7 +23,7 @@ const speedRegex = /speed=\s*(-?\d+(,\d+)*(\.\d+(e\d+)?)?)/gm;
 // https://trac.ffmpeg.org/ticket/309
 const makeEven = n => 2 * Math.round(n / 2);
 
-const areDimensionsEvent = ({width, height}) => width % 2 === 0 && height % 2 === 0;
+const areDimensionsEven = ({width, height}) => width % 2 === 0 && height % 2 === 0;
 
 const getRunFunction = (shouldTrack, mode = 'convert') => (outputPath, options, args) => {
   const modes = new Map([
@@ -144,7 +144,7 @@ const convertToMp4 = PCancelable.fn(async (options, onCancel) => {
     '-i', options.inputPath,
     '-r', options.fps,
     ...(
-      options.shouldCrop || !areDimensionsEvent(options) ? [
+      options.shouldCrop || !areDimensionsEven(options) ? [
         '-s', `${makeEven(options.width)}x${makeEven(options.height)}`,
         '-ss', options.startTime,
         '-to', options.endTime
@@ -203,7 +203,7 @@ const convertToAv1 = PCancelable.fn(async (options, onCancel) => {
     '-i', options.inputPath,
     '-r', options.fps,
     ...(
-      options.shouldCrop || !areDimensionsEvent(options) ? [
+      options.shouldCrop || !areDimensionsEven(options) ? [
         '-s', `${makeEven(options.width)}x${makeEven(options.height)}`,
         '-ss', options.startTime,
         '-to', options.endTime
@@ -214,6 +214,8 @@ const convertToAv1 = PCancelable.fn(async (options, onCancel) => {
     '-crf', '34',
     '-b:v', '0',
     '-strict', 'experimental',
+    // Enables row-based multi-threading which maximizes CPU usage
+    // https://trac.ffmpeg.org/wiki/Encode/AV1
     '-cpu-used', '4',
     '-row-mt', '1',
     '-tiles', '2x2',

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -15,7 +15,8 @@ const exportUsageHistory = new Store({
     apng: {lastUsed: 1, plugins: {default: 1}},
     webm: {lastUsed: 2, plugins: {default: 1}},
     mp4: {lastUsed: 3, plugins: {default: 1}},
-    gif: {lastUsed: 4, plugins: {default: 1}}
+    gif: {lastUsed: 4, plugins: {default: 1}},
+    av1: {lastUsed: 5, plugins: {default: 1}}
   }
 });
 
@@ -41,6 +42,11 @@ const fpsUsageHistory = new Store({
       type: 'number',
       minimum: 0,
       default: 60
+    },
+    av1: {
+      type: 'number',
+      minimum: 0,
+      default: 60
     }
   }
 });
@@ -50,7 +56,8 @@ const prettifyFormat = format => {
     ['apng', 'APNG'],
     ['gif', 'GIF'],
     ['mp4', 'MP4'],
-    ['webm', 'WebM']
+    ['webm', 'WebM'],
+    ['av1', 'AV1']
   ]);
 
   return formats.get(format);

--- a/main/export-options.js
+++ b/main/export-options.js
@@ -55,9 +55,9 @@ const prettifyFormat = format => {
   const formats = new Map([
     ['apng', 'APNG'],
     ['gif', 'GIF'],
-    ['mp4', 'MP4'],
-    ['webm', 'WebM'],
-    ['av1', 'AV1']
+    ['mp4', 'MP4 (H264)'],
+    ['av1', 'MP4 (AV1)'],
+    ['webm', 'WebM']
   ]);
 
   return formats.get(format);

--- a/main/export.js
+++ b/main/export.js
@@ -7,6 +7,7 @@ const moment = require('moment');
 const {track} = require('./common/analytics');
 const {convertTo} = require('./convert');
 const {ShareServiceContext} = require('./service-context');
+const {getFormatExtension} = require('./common/constants');
 const PluginConfig = require('./utils/plugin-config');
 
 class Export {
@@ -42,7 +43,7 @@ class Export {
 
     const now = moment();
     const fileName = options.recordingName || (options.isNewRecording ? `Kapture ${now.format('YYYY-MM-DD')} at ${now.format('H.mm.ss')}` : path.parse(this.inputPath).name);
-    this.defaultFileName = `${fileName}.${this.format}`;
+    this.defaultFileName = `${fileName}.${getFormatExtension(this.format)}`;
 
     this.context = new ShareServiceContext({
       _isBuiltin: options.sharePlugin.pluginName.startsWith('_'),
@@ -134,7 +135,7 @@ class Export {
     this.convertProcess = convertTo(
       {
         ...this.exportOptions,
-        defaultFileName: fileType ? `${path.parse(this.defaultFileName).name}.${fileType}` : this.defaultFileName,
+        defaultFileName: fileType ? `${path.parse(this.defaultFileName).name}.${getFormatExtension(fileType)}` : this.defaultFileName,
         inputPath: this.inputPath,
         onProgress: (percentage, estimate, action = 'Converting') => this.setProgress(estimate ? `${action} — ${estimate} remaining` : `${action}…`, percentage),
         editService: this.editService ? {

--- a/main/plugins/open-with-plugin.js
+++ b/main/plugins/open-with-plugin.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const {getAppsThatOpenExtension, openFileWithApp} = require('mac-open-with');
+const {getFormatExtension} = require('../common/constants');
 
 const action = async context => {
   const filePath = await context.filePath();
@@ -8,10 +9,10 @@ const action = async context => {
 };
 
 const apps = new Map(
-  ['mp4', 'gif', 'apng', 'webm']
-    .map(extension => [
-      extension,
-      getAppsThatOpenExtension.sync(extension)
+  ['mp4', 'gif', 'apng', 'webm', 'av1']
+    .map(format => [
+      format,
+      getAppsThatOpenExtension.sync(getFormatExtension(format))
         .map(app => ({
           ...app,
           name: decodeURI(path.parse(app.url).name)

--- a/main/plugins/save-file-plugin.js
+++ b/main/plugins/save-file-plugin.js
@@ -31,7 +31,8 @@ const saveFile = {
     'gif',
     'mp4',
     'webm',
-    'apng'
+    'apng',
+    'av1'
   ],
   action
 };

--- a/renderer/components/editor/options/right.js
+++ b/renderer/components/editor/options/right.js
@@ -111,7 +111,7 @@ class RightOptions extends React.Component {
 
           .format {
             height: 24px;
-            width: 80px;
+            width: 96px;
             margin-right: 8px;
           }
 

--- a/test/helpers/mocks.js
+++ b/test/helpers/mocks.js
@@ -19,4 +19,5 @@ module.exports.mockImport = (importPath, mock) => {
   }
 
   moduleAlias.addAlias(importPath, mockModulePath);
+  return require(mockModulePath);
 };

--- a/test/mocks/settings.js
+++ b/test/mocks/settings.js
@@ -1,5 +1,17 @@
 'use strict';
+const sinon = require('sinon');
+
+const mocks = {};
+
+const mockGet = sinon.fake((key, defaultValue) => {
+  return mocks[key] || defaultValue;
+});
 
 module.exports = {
-  get: () => {}
+  get: mockGet,
+  set: sinon.fake(),
+  delete: sinon.fake(),
+  setMock: (key, value) => {
+    mocks[key] = value;
+  }
 };

--- a/test/mocks/settings.js
+++ b/test/mocks/settings.js
@@ -3,9 +3,7 @@ const sinon = require('sinon');
 
 const mocks = {};
 
-const mockGet = sinon.fake((key, defaultValue) => {
-  return mocks[key] || defaultValue;
-});
+const mockGet = sinon.fake((key, defaultValue) => mocks[key] || defaultValue);
 
 module.exports = {
   get: mockGet,


### PR DESCRIPTION
Closes #221 

Also added tests for the recent lossy gif addition to the convert file

Was able to get a pretty good set of options. Conversions take a little longer than the rest of the formats but not unreasonable if you reduce the size/fps from the original. But, even so, if someone uses AV1 it'd be because they understand it takes longer to encode, but it's better for multiple subsequent plays


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#221: AV1 support](https://issuehunt.io/repos/65411043/issues/221)
---
</details>
<!-- /Issuehunt content-->