### PR TITLE
Actually return devices

### DIFF
--- a/main/common/settings.js
+++ b/main/common/settings.js
@@ -134,7 +134,7 @@ module.exports.getSelectedInputDeviceId = () => {
 
   if (audioInputDeviceId === defaultInputDeviceId) {
     const device = getDefaultInputDevice();
-    return device.id;
+    return device && device.id;
   }
 
   return audioInputDeviceId;

--- a/main/menus.js
+++ b/main/menus.js
@@ -132,7 +132,7 @@ const getMicrophoneItem = async () => {
         click: () => settings.set('recordAudio', false)
       },
       ...[
-        {name: `System Default (${currentDefaultDevice.name})`, id: defaultInputDeviceId},
+        {name: `System Default${currentDefaultDevice ? ` (${currentDefaultDevice.name})` : ''}`, id: defaultInputDeviceId},
         ...devices
       ].map(device => ({
         label: device.name,

--- a/main/utils/devices.js
+++ b/main/utils/devices.js
@@ -30,11 +30,18 @@ const getAudioDevices = async () => {
       return 0;
     }).map(device => ({id: device.uid, name: device.name}));
   } catch (error) {
-    const devices = await aperture.audioDevices();
+    try {
+      const devices = await aperture.audioDevices();
 
-    if (!Array.isArray(devices)) {
-      const Sentry = require('./sentry');
-      Sentry.captureException(new Error(`devices is not an array: ${JSON.stringify(devices)}`));
+      if (!Array.isArray(devices)) {
+        const Sentry = require('./sentry');
+        Sentry.captureException(new Error(`devices is not an array: ${JSON.stringify(devices)}`));
+        showError(error);
+        return [];
+      }
+
+      return devices;
+    } catch (error) {
       showError(error);
       return [];
     }

--- a/main/utils/devices.js
+++ b/main/utils/devices.js
@@ -49,11 +49,15 @@ const getAudioDevices = async () => {
 };
 
 const getDefaultInputDevice = () => {
-  const device = audioDevices.getDefaultInputDevice.sync();
-  return {
-    id: device.uid,
-    name: device.name
-  };
+  try {
+    const device = audioDevices.getDefaultInputDevice.sync();
+    return {
+      id: device.uid,
+      name: device.name
+    };
+  } catch {
+    // Running on 10.13 and don't have swift support libs. No need to report
+  }
 };
 
 module.exports = {getAudioDevices, getDefaultInputDevice};

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -43,12 +43,12 @@ export default class PreferencesContainer extends Container {
   getAudioDevices = async () => {
     const {getAudioDevices, getDefaultInputDevice} = this.remote.require('./utils/devices');
     const {audioInputDeviceId} = this.settings.store;
-    const {name: currentDefaultName} = getDefaultInputDevice();
+    const {name: currentDefaultName} = getDefaultInputDevice() || {};
 
     const audioDevices = await getAudioDevices();
     const updates = {
       audioDevices: [
-        {name: `System Default (${currentDefaultName})`, id: defaultInputDeviceId},
+        {name: `System Default${currentDefaultName ? ` (${currentDefaultName})` : ''}`, id: defaultInputDeviceId},
         ...audioDevices
       ],
       audioInputDeviceId


### PR DESCRIPTION
Fixes #913 
Fixes #914 

When we use aperture.devices fallback, I forgot to actually return the devices array

Also fixes the issue for when the user is on 10.13, and doesn't have swift libs installed, where we can't get the system default device (aperture doesn't return that). So it hides the name from the menus, and if it's selected at the time of recording, we just pick the first input in the list as the "default".