### PR TITLE
Replace first-run with electron-util's `isFirstAppLaunch`

### DIFF
--- a/main/common/analytics.js
+++ b/main/common/analytics.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const firstRun = require('first-run');
+const util = require('electron-util');
 const Insight = require('insight');
 const {parse} = require('semver');
 const pkg = require('../../package');
@@ -20,12 +20,13 @@ const track = (...paths) => {
 };
 
 const initializeAnalytics = () => {
-  if (firstRun()) {
+  if (util.isFirstAppLaunch()) {
     insight.track('install');
   }
 
-  if (firstRun({name: `${pkg.name}-${pkg.version}`})) {
+  if (settings.get('version') !== pkg.version) {
     track('install');
+    settings.set('version', pkg.version);
   }
 };
 

--- a/main/common/settings.js
+++ b/main/common/settings.js
@@ -95,6 +95,10 @@ const store = new Store({
       type: 'object',
       properties: Object.keys(shortcuts).reduce((acc, key) => ({...acc, [key]: shortcutSchema}), {}),
       default: {}
+    },
+    version: {
+      type: 'string',
+      default: ''
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "ensure-error": "^2.0.0",
     "execa": "4.0.0",
     "file-icon": "^3.0.0",
-    "first-run": "^2.0.0",
     "gifsicle": "^5.0.0",
     "got": "^9.6.0",
     "insight": "^0.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3211,18 +3211,6 @@ config-chain@^1.1.11:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-configstore@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/configstore/-/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"
-  integrity sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==
-  dependencies:
-    dot-prop "^4.1.0"
-    graceful-fs "^4.1.2"
-    make-dir "^1.0.0"
-    unique-string "^1.0.0"
-    write-file-atomic "^2.0.0"
-    xdg-basedir "^3.0.0"
-
 configstore@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
@@ -5234,14 +5222,6 @@ find-versions@^3.0.0, find-versions@^3.2.0:
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
   dependencies:
     semver-regex "^2.0.0"
-
-first-run@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/first-run/-/first-run-2.0.0.tgz#0586318e8ef1b2df55a98542a1b8eaca1230c091"
-  integrity sha512-p+FmKUqQ1qlZC6uSMALdWU8bnXpcJ0Jhdr85a3BD6yly7rjKIXH5S38i6f2kmKNHoFec4brdmrvmIWnleeNirg==
-  dependencies:
-    configstore "^4.0.0"
-    read-pkg-up "^5.0.0"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -9106,14 +9086,6 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
-read-pkg-up@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-5.0.0.tgz#b6a6741cb144ed3610554f40162aa07a6db621b8"
-  integrity sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==
-  dependencies:
-    find-up "^3.0.0"
-    read-pkg "^5.0.0"
-
 read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -9150,7 +9122,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^5.0.0, read-pkg@^5.2.0:
+read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
   integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
@@ -11229,7 +11201,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.0.0, write-file-atomic@^2.3.0:
+write-file-atomic@^2.3.0:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
   integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
@@ -11254,11 +11226,6 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
-
-xdg-basedir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes #887 
Fixes #922 

Replaces `first-run` with the `isFirstAppLaunch` method from electron-util, and a field in settings for tracking the version (since `isFirstAppLaunch` does not support a parameter like `first-run` did)