### PR TITLE
Update cask installation command for Homebrew 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Or install with [Homebrew-Cask](https://caskroom.github.io):
 
 ```
-$ brew cask install kap
+$ brew install --cask kap
 ```
 
 ## Contribute


### PR DESCRIPTION
Hi there,

First of all, thanks so much for Kap - it's really great.

Just a quick PR to change the Homebrew cask upgrade for [the `2.6.0` upgrade](https://brew.sh/2020/12/01/homebrew-2.6.0/):

> All `brew cask` commands have been deprecated in favour of `brew` commands (with `--cask`) when necessary