### PR TITLE
Respect explicitly passed `fileType` for plugins

### DIFF
--- a/main/conversion.ts
+++ b/main/conversion.ts
@@ -146,7 +146,7 @@ export default class Conversion extends EventEmitter {
     }
 
     if (!this.conversionProcess || (this.requestedFileType !== fileType)) {
-      this.start();
+      this.start(fileType);
     }
 
     this.requestedFileType = fileType;
@@ -242,9 +242,9 @@ export default class Conversion extends EventEmitter {
     } catch {}
   };
 
-  private readonly start = () => {
+  private readonly start = (fileType?: Format) => {
     this.conversionProcess = convertTo(
-      this.format,
+      fileType ?? this.format,
       {
         ...this.options,
         defaultFileName: this.video.title,


### PR DESCRIPTION
Fix explicitly passed fileType for the conversion for plugins like Gifski. It was not working after the TS rewrite