### PR TITLE
Added undo / redo stack for cropper

### DIFF
--- a/renderer/containers/cropper.js
+++ b/renderer/containers/cropper.js
@@ -356,7 +356,7 @@ export default class CropperContainer extends Container {
       this.setBounds({x, y, width, height});
       this.setState({isMoving: false, showHandles: true});
       this.cursorContainer.removeCursorObserver(this.move);
-      //this.updateSettings({x, y}); <-- do we need this? since it alreadly calls setBounds which updates Settings
+      // Check: this.updateSettings({x, y}); <-- do we need this? since it alreadly calls setBounds which updates Settings
     }
   };
 

--- a/renderer/pages/cropper.js
+++ b/renderer/pages/cropper.js
@@ -97,6 +97,12 @@ export default class CropperPage extends React.Component {
         this.remote.getCurrentWindow().setIgnoreMouseEvents(true);
         this.dev = !this.dev;
         break;
+      case 'z':
+        cropperContainer.undo();
+        break;
+      case 'y':
+        cropperContainer.redo();
+        break;
       default:
         break;
     }

--- a/renderer/pages/cropper.js
+++ b/renderer/pages/cropper.js
@@ -20,6 +20,8 @@ actionBarContainer.bindCursor(cursorContainer);
 actionBarContainer.bindCropper(cropperContainer);
 
 let lastRatioLockState = null;
+let metaKeyDown = false;
+let ShiftDown = false;
 
 export default class CropperPage extends React.Component {
   remote = electron.remote || false;
@@ -76,6 +78,16 @@ export default class CropperPage extends React.Component {
   }
 
   handleKeyEvent = event => {
+    if (event.metaKey && event.type === 'keydown') {
+      metaKeyDown = true;
+    } else if (event.metaKey && event.type === 'keyup') {
+      metaKeyDown = false;
+    }
+    if (event.key === 'Shift' && event.type === 'keydown') {
+      ShiftDown = true;
+    } else if (event.key === 'Shift' && event.type === 'keyup') {
+      ShiftDown = false;
+    }
     switch (event.key) {
       case 'Escape':
         this.remote.getCurrentWindow().close();
@@ -98,10 +110,12 @@ export default class CropperPage extends React.Component {
         this.dev = !this.dev;
         break;
       case 'z':
-        cropperContainer.undo();
-        break;
-      case 'y':
-        cropperContainer.redo();
+        if (metaKeyDown && ShiftDown){
+          cropperContainer.redo();
+        } else if (metaKeyDown && !ShiftDown) {
+          cropperContainer.undo();
+        }
+        
         break;
       default:
         break;

--- a/renderer/pages/cropper.js
+++ b/renderer/pages/cropper.js
@@ -83,11 +83,13 @@ export default class CropperPage extends React.Component {
     } else if (event.metaKey && event.type === 'keyup') {
       metaKeyDown = false;
     }
+
     if (event.key === 'Shift' && event.type === 'keydown') {
       ShiftDown = true;
     } else if (event.key === 'Shift' && event.type === 'keyup') {
       ShiftDown = false;
     }
+
     switch (event.key) {
       case 'Escape':
         this.remote.getCurrentWindow().close();
@@ -110,12 +112,12 @@ export default class CropperPage extends React.Component {
         this.dev = !this.dev;
         break;
       case 'z':
-        if (metaKeyDown && ShiftDown){
+        if (metaKeyDown && ShiftDown) {
           cropperContainer.redo();
         } else if (metaKeyDown && !ShiftDown) {
           cropperContainer.undo();
         }
-        
+
         break;
       default:
         break;


### PR DESCRIPTION
I added a stack to keep track of each cropper state whenever the cropper is adjusted or edited. The user can now press the 'z' key for undo or 'y' key for redo and the cropper will be adjusted accordingly. 

This added feature is in response to #976  