### PR TITLE
Fix README download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Get Kap
 
-**[Download the latest release](https://kap.now.sh/api)** (macOS only)
+**[Download the latest release](https://getkap.co/download)** (macOS only)
 
 Or install with [Homebrew-Cask](https://caskroom.github.io):
 


### PR DESCRIPTION
This pull request updates the download link at the top of the README for this repo, ultimately fixing the location.

Fixes #1013 