### PR TITLE
Electron v10

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -1,4 +1,4 @@
-import {app} from 'electron';
+import {app, protocol} from 'electron';
 import {is, enforceMacOSAppLocation} from 'electron-util';
 import log from 'electron-log';
 import {autoUpdater} from 'electron-updater';
@@ -101,6 +101,11 @@ const checkForUpdates = () => {
   if (!app.isDefaultProtocolClient('kap')) {
     app.setAsDefaultProtocolClient('kap');
   }
+
+  protocol.registerFileProtocol('file', (request, callback) => {
+    const pathname = decodeURI(request.url.replace('file:///', ''));
+    callback(pathname);
+  });
 
   if (filesToOpen.length > 0) {
     track('editor/opened/startup');

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,4 +1,4 @@
-import {app, protocol} from 'electron';
+import {app} from 'electron';
 import {is, enforceMacOSAppLocation} from 'electron-util';
 import log from 'electron-log';
 import {autoUpdater} from 'electron-updater';
@@ -22,6 +22,7 @@ import {hasActiveRecording, cleanPastRecordings} from './recording-history';
 import {setupRemoteStates} from './remote-states';
 import {setUpExportsListeners} from './export';
 import {windowManager} from './windows/manager';
+import {setupProtocol} from './utils/protocol';
 
 const prepareNext = require('electron-next');
 
@@ -82,6 +83,8 @@ const checkForUpdates = () => {
   // Initialize remote states
   setupRemoteStates();
 
+  setupProtocol();
+
   app.dock.hide();
   app.setAboutPanelOptions({copyright: 'Copyright © Wulkano'});
 
@@ -101,11 +104,6 @@ const checkForUpdates = () => {
   if (!app.isDefaultProtocolClient('kap')) {
     app.setAsDefaultProtocolClient('kap');
   }
-
-  protocol.registerFileProtocol('file', (request, callback) => {
-    const pathname = decodeURI(request.url.replace('file:///', ''));
-    callback(pathname);
-  });
 
   if (filesToOpen.length > 0) {
     track('editor/opened/startup');

--- a/main/plugins/plugin.ts
+++ b/main/plugins/plugin.ts
@@ -155,8 +155,7 @@ export class InstalledPlugin extends BasePlugin {
   openConfig = () => windowManager.config?.open(this.name);
 
   openConfigInEditor = () => {
-    // TODO: replace with `this.config.openInEditor()` when we upgrade to an Electron version that has `shell.openPath()`
-    shell.openItem(this.config.path);
+    return this.config.openInEditor();
   };
 
   private readonly getSetEnableFunction = (service: RecordService) => async (enabled: boolean) => {

--- a/main/tray.ts
+++ b/main/tray.ts
@@ -38,8 +38,6 @@ export const resetTray = () => {
     clearTimeout(trayAnimation);
   }
 
-  // TODO: figure out why it's marked like this. Tray extends EventEmitter, so removeAllListeners should be available
-  // @ts-expect-error
   tray.removeAllListeners('click');
 
   tray.setImage(path.join(__dirname, '..', 'static', 'menubarDefaultTemplate.png'));

--- a/main/utils/protocol.ts
+++ b/main/utils/protocol.ts
@@ -1,0 +1,10 @@
+import {protocol} from 'electron';
+
+export const setupProtocol = () => {
+  // Fix protocol issue in order to support loading editor previews
+  // https://github.com/electron/electron/issues/23757#issuecomment-640146333
+  protocol.registerFileProtocol('file', (request, callback) => {
+    const pathname = decodeURI(request.url.replace('file:///', ''));
+    callback(pathname);
+  });
+};

--- a/main/windows/config.ts
+++ b/main/windows/config.ts
@@ -50,7 +50,8 @@ const openEditorConfigWindow = async (pluginName: string, serviceTitle: string, 
     parent: editorWindow,
     modal: true,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
 

--- a/main/windows/cropper.ts
+++ b/main/windows/cropper.ts
@@ -46,7 +46,8 @@ const openCropper = (display: Display, activeDisplayId?: number) => {
     transparent: true,
     show: false,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
 
@@ -153,7 +154,6 @@ const openCropperWindow = async () => {
 
     const wasFocused = cropper.isFocused();
 
-    // @ts-expect-error
     cropper.removeAllListeners('closed');
     cropper.destroy();
     croppers.delete(id);
@@ -176,7 +176,6 @@ const preventDefault = (event: any) => event.preventDefault();
 
 const selectApp = async (window: MacWindow, activateWindow: (ownerName: string) => Promise<void>) => {
   for (const cropper of croppers.values()) {
-    // @ts-expect-error
     cropper.prependListener('blur', preventDefault);
   }
 
@@ -213,7 +212,6 @@ const disableCroppers = () => {
   }
 
   for (const cropper of croppers.values()) {
-    // @ts-expect-error
     cropper.removeAllListeners('blur');
     cropper.setIgnoreMouseEvents(true);
     cropper.setVisibleOnAllWorkspaces(true);

--- a/main/windows/dialog.ts
+++ b/main/windows/dialog.ts
@@ -25,7 +25,8 @@ const showDialog = async (options: DialogOptions) => new Promise<number | void>(
     title: '',
     useContentSize: true,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
 

--- a/main/windows/editor.ts
+++ b/main/windows/editor.ts
@@ -40,7 +40,6 @@ const open = async (video: Video) => {
     height: MIN_WINDOW_HEIGHT,
     backgroundColor: '#222222',
     webPreferences: {
-      nodeIntegration: true,
       webSecurity: !is.development // Disable webSecurity in dev to load video over file:// protocol while serving over insecure http, this is not needed in production where we use file:// protocol for html serving.
     },
     frame: false,

--- a/main/windows/kap-window.ts
+++ b/main/windows/kap-window.ts
@@ -39,7 +39,7 @@ export default class KapWindow<State = any> {
   private readonly cleanupMethods: Array<() => void> = [];
   private readonly options: KapWindowOptions<State>;
 
-  constructor(props: KapWindowOptions<State>) {
+  constructor(private readonly props: KapWindowOptions<State>) {
     const {
       route,
       waitForMount,
@@ -51,6 +51,7 @@ export default class KapWindow<State = any> {
       ...rest,
       webPreferences: {
         nodeIntegration: true,
+        enableRemoteModule: true,
         ...rest.webPreferences
       },
       show: false
@@ -67,7 +68,6 @@ export default class KapWindow<State = any> {
 
     this.state = initialState;
     this.generateMenu();
-    loadRoute(this.browserWindow, route);
     this.readyPromise = this.setupWindow();
   }
 
@@ -142,6 +142,10 @@ export default class KapWindow<State = any> {
         this.callRenderer('kap-window-state', this.state);
       }
     });
+
+    this.answerRenderer('kap-window-state', () => this.state);
+
+    loadRoute(this.browserWindow, this.props.route);
 
     if (waitForMount) {
       return new Promise<void>(resolve => {

--- a/main/windows/preferences.ts
+++ b/main/windows/preferences.ts
@@ -38,7 +38,8 @@ const openPrefsWindow = async (options?: PreferencesWindowOptions) => {
     transparent: true,
     vibrancy: 'window',
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
+      enableRemoteModule: true
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@typescript-eslint/parser": "^4.15.0",
     "ava": "^3.15.0",
     "babel-eslint": "^10.1.0",
-    "electron": "8.2.4",
+    "electron": "10.4.6",
     "electron-builder": "^22.10.5",
     "electron-builder-notarize": "^1.2.0",
     "eslint-config-xo": "^0.35.0",

--- a/renderer/components/exports/export.tsx
+++ b/renderer/components/exports/export.tsx
@@ -7,7 +7,6 @@ import {CancelIcon, MoreIcon} from '../../vectors';
 import {Progress, ProgressSpinner} from './progress';
 import useConversion from '../../hooks/editor/use-conversion';
 import {ExportStatus} from '../../common/types';
-import util from 'electron-util';
 import {useShowWindow} from '../../hooks/use-show-window';
 
 const stopPropagation = event => event.stopPropagation();
@@ -41,7 +40,8 @@ const Export = ({id}: {id: string}) => {
   }, [isActionable, state?.id]);
 
   const menu = useMemo(() => {
-    return util.api.Menu.buildFromTemplate([{
+    const {api} = require('electron-util');
+    return api.Menu.buildFromTemplate([{
       label: 'Open Original',
       click: openInEditor
     },

--- a/renderer/components/preferences/categories/general.js
+++ b/renderer/components/preferences/categories/general.js
@@ -29,7 +29,7 @@ class General extends React.Component {
   }
 
   openKapturesDir = () => {
-    electron.shell.openItem(this.props.kapturesDir);
+    electron.shell.openPath(this.props.kapturesDir);
   };
 
   render() {

--- a/renderer/containers/preferences.js
+++ b/renderer/containers/preferences.js
@@ -199,7 +199,7 @@ export default class PreferencesContainer extends Container {
     this.setOverlay(false);
   };
 
-  openPluginsFolder = () => electron.shell.openItem(this.plugins.pluginsDir);
+  openPluginsFolder = () => electron.shell.openPath(this.plugins.pluginsDir);
 
   selectCategory = category => {
     this.setState({category});

--- a/renderer/hooks/window-state.tsx
+++ b/renderer/hooks/window-state.tsx
@@ -7,6 +7,8 @@ export const WindowStateProvider = (props: {children: ReactNode}) => {
   const [windowState, setWindowState] = useState();
 
   useEffect(() => {
+    ipc.callMain('kap-window-state').then(setWindowState);
+
     return ipc.answerMain('kap-window-state', (newState: any) => {
       setWindowState(newState);
     });

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -5,7 +5,6 @@ import GlobalStyles from '../utils/global-styles';
 import SentryErrorBoundary from '../utils/sentry-error-boundary';
 import {WindowStateProvider} from '../hooks/window-state';
 import classNames from 'classnames';
-import {ipcRenderer} from 'electron-better-ipc';
 
 const Kap = (props: AppProps) => {
   const [isMounted, setIsMounted] = useState(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,10 +3356,10 @@ electron-util@^0.8.2:
   dependencies:
     electron-is-dev "^0.3.0"
 
-electron@8.2.4:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-8.2.4.tgz#c4e51ca8e84b5a5beaaabdae1024bd52ba487ba4"
-  integrity sha512-Lle0InIgSAHZxD5KDY0wZ1A2Zlc6GHwMhAxoHMzn05mndyP1YBkCYHc0TDDofzUTrsLFofduPjlknO5Oj9fTPA==
+electron@10.4.6:
+  version "10.4.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-10.4.6.tgz#1f69e5c2394c3e6cc0f7b610d5bed06a0709c68c"
+  integrity sha512-HCKJrWy9ZF4x7dOE8Q3+lXFVz/We7D+4mAZJHtwdeZT3EjcGrm575TsuuzY8AOUASohmezaBANcSmJy0zVlAzw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
Upgraded to v9 originally, fixed the issues.

Then I saw with the end of support message here: https://www.electronjs.org/blog/electron-12-0

So I decided to try to go to v10 as well, only breaking change from 9 -> 10 was the explicit `enableRemoteModule: true`


This is a PR to the exports PR branch that is also open. Made a decent amount of changes so I didn't want to miss any issue in those in the version upgrades