### PR TITLE
Add support for HEVC, use ffmpeg-static

### DIFF
--- a/main/common/constants.ts
+++ b/main/common/constants.ts
@@ -3,12 +3,12 @@ import {Format} from './types';
 export const supportedVideoExtensions = ['mp4', 'mov', 'm4v'];
 
 const formatExtensions = new Map([
-  ['av1', 'mp4']
+  ['av1', 'mp4'],
+  ['hevc', 'mp4']
 ]);
 
-export const formats = [Format.mp4, Format.av1, Format.gif, Format.apng, Format.webm];
+export const formats = [Format.mp4, Format.hevc, Format.av1, Format.gif, Format.apng, Format.webm];
 
 export const getFormatExtension = (format: Format) => formatExtensions.get(format) ?? format;
 
 export const defaultInputDeviceId = 'SYSTEM_DEFAULT';
-

--- a/main/common/types/base.ts
+++ b/main/common/types/base.ts
@@ -2,6 +2,7 @@ import {Rectangle} from 'electron';
 
 export enum Format {
   gif = 'gif',
+  hevc = 'hevc',
   mp4 = 'mp4',
   webm = 'webm',
   apng = 'apng',

--- a/main/converters/h264.ts
+++ b/main/converters/h264.ts
@@ -205,6 +205,38 @@ const convertToAv1 = (options: ConvertOptions) => convert(options.outputPath, {
 ));
 
 // eslint-disable-next-line @typescript-eslint/promise-function-async
+const convertToHevc = (options: ConvertOptions) => convert(options.outputPath, {
+  onProgress: (progress, estimate) => {
+    options.onProgress('Converting', progress, estimate);
+  },
+  startTime: options.startTime,
+  endTime: options.endTime
+}, conditionalArgs(
+  '-i', options.inputPath,
+  '-r', options.fps.toString(),
+  '-c:v', 'libx265',
+  '-c:a', 'libopus',
+  '-preset', 'medium',
+  '-tag:v', 'hvc1', // Metadata for macOS
+  {
+    args: ['-an'],
+    if: options.shouldMute
+  },
+  {
+    args: [
+      '-s',
+      `${makeEven(options.width)}x${makeEven(options.height)}`,
+      '-ss',
+      options.startTime.toString(),
+      '-to',
+      options.endTime.toString()
+    ],
+    if: options.shouldCrop || !areDimensionsEven(options)
+  },
+  options.outputPath
+));
+
+// eslint-disable-next-line @typescript-eslint/promise-function-async
 const convertToApng = (options: ConvertOptions) => convert(options.outputPath, {
   onProgress: (progress, estimate) => {
     options.onProgress('Converting', progress, estimate);
@@ -250,6 +282,7 @@ export const crop = (options: ConvertOptions) => convert(options.outputPath, {
 export default new Map([
   [Format.gif, convertToGif],
   [Format.mp4, convertToMp4],
+  [Format.hevc, convertToHevc],
   [Format.webm, convertToWebm],
   [Format.apng, convertToApng],
   [Format.av1, convertToAv1]

--- a/main/converters/process.ts
+++ b/main/converters/process.ts
@@ -9,10 +9,9 @@ import {track} from '../common/analytics';
 import {conditionalArgs, extractProgressFromStderr} from './utils';
 import {settings} from '../common/settings';
 
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-const gifsicle = require('gifsicle');
+import ffmpegPath from '../utils/ffmpeg-path';
 
-const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
+const gifsicle = require('gifsicle');
 const gifsiclePath = util.fixPathForAsarUnpack(gifsicle);
 
 enum Mode {

--- a/main/plugins/built-in/open-with-plugin.ts
+++ b/main/plugins/built-in/open-with-plugin.ts
@@ -30,7 +30,7 @@ const getAppsForFormat = (format: Format) => {
     });
 };
 
-const appsForFormat = (['mp4', 'gif', 'apng', 'webm', 'av1'] as Format[])
+const appsForFormat = (['mp4', 'gif', 'apng', 'webm', 'av1', 'hevc'] as Format[])
   .map(format => ({
     format,
     apps: getAppsForFormat(format)
@@ -44,4 +44,3 @@ export const shareServices = [{
   formats: [...apps.keys()],
   action
 }];
-

--- a/main/plugins/built-in/save-file-plugin.ts
+++ b/main/plugins/built-in/save-file-plugin.ts
@@ -41,7 +41,8 @@ const saveFile = {
     'mp4',
     'webm',
     'apng',
-    'av1'
+    'av1',
+    'hevc'
   ],
   action
 };
@@ -53,7 +54,8 @@ const filterMap = new Map([
   [Format.webm, [{name: 'Movies', extensions: ['webm']}]],
   [Format.gif, [{name: 'Images', extensions: ['gif']}]],
   [Format.apng, [{name: 'Images', extensions: ['apng']}]],
-  [Format.av1, [{name: 'Movies', extensions: ['mp4']}]]
+  [Format.av1, [{name: 'Movies', extensions: ['mp4']}]],
+  [Format.hevc, [{name: 'Movies', extensions: ['mp4']}]]
 ]);
 
 let lastSavedDirectory: string;
@@ -83,4 +85,3 @@ export const askForTargetFilePath = async (
 
   return undefined;
 };
-

--- a/main/recording-history.ts
+++ b/main/recording-history.ts
@@ -4,7 +4,6 @@
 import {shell, clipboard} from 'electron';
 import fs from 'fs';
 import Store from 'electron-store';
-import util from 'electron-util';
 import execa from 'execa';
 import tempy from 'tempy';
 import {SetOptional} from 'type-fest';
@@ -16,8 +15,7 @@ import {Video} from './video';
 import {ApertureOptions} from './common/types';
 import Sentry, {isSentryEnabled} from './utils/sentry';
 
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
+import ffmpegPath from './utils/ffmpeg-path';
 
 export interface PastRecording {
   filePath: string;

--- a/main/remote-states/editor-options.ts
+++ b/main/remote-states/editor-options.ts
@@ -10,9 +10,9 @@ const exportUsageHistory = new Store<{[key in Format]: {lastUsed: number; plugin
   name: 'export-usage-history',
   defaults: {
     gif: {lastUsed: 6, plugins: {default: 1}},
-    hevc: {lastUsed: 5, plugins: {default: 1}},
-    mp4: {lastUsed: 4, plugins: {default: 1}},
-    webm: {lastUsed: 3, plugins: {default: 1}},
+    mp4: {lastUsed: 5, plugins: {default: 1}},
+    webm: {lastUsed: 4, plugins: {default: 1}},
+    hevc: {lastUsed: 3, plugins: {default: 1}},
     av1: {lastUsed: 2, plugins: {default: 1}},
     apng: {lastUsed: 1, plugins: {default: 1}}
   }

--- a/main/remote-states/editor-options.ts
+++ b/main/remote-states/editor-options.ts
@@ -9,7 +9,8 @@ import {prettifyFormat} from '../utils/formats';
 const exportUsageHistory = new Store<{[key in Format]: {lastUsed: number; plugins: Record<string, number>}}>({
   name: 'export-usage-history',
   defaults: {
-    gif: {lastUsed: 5, plugins: {default: 1}},
+    gif: {lastUsed: 6, plugins: {default: 1}},
+    hevc: {lastUsed: 5, plugins: {default: 1}},
     mp4: {lastUsed: 4, plugins: {default: 1}},
     webm: {lastUsed: 3, plugins: {default: 1}},
     av1: {lastUsed: 2, plugins: {default: 1}},
@@ -41,6 +42,11 @@ const fpsUsageHistory = new Store<{[key in Format]: number}>({
       default: 60
     },
     av1: {
+      type: 'number',
+      minimum: 0,
+      default: 60
+    },
+    hevc: {
       type: 'number',
       minimum: 0,
       default: 60

--- a/main/utils/encoding.ts
+++ b/main/utils/encoding.ts
@@ -1,13 +1,10 @@
 /* eslint-disable array-element-newline */
 
 import path from 'path';
-import util from 'electron-util';
 import execa from 'execa';
 import tempy from 'tempy';
 import {track} from '../common/analytics';
-
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
+import ffmpegPath from './ffmpeg-path';
 
 export const getEncoding = async (filePath: string) => {
   try {

--- a/main/utils/ffmpeg-path.ts
+++ b/main/utils/ffmpeg-path.ts
@@ -1,0 +1,6 @@
+import ffmpeg from 'ffmpeg-static';
+import util from 'electron-util';
+
+const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg);
+
+export default ffmpegPath;

--- a/main/utils/formats.ts
+++ b/main/utils/formats.ts
@@ -2,6 +2,7 @@ import {Format} from '../common/types';
 
 const formats = new Map([
   [Format.gif, 'GIF'],
+  [Format.hevc, 'MP4 (H265)'],
   [Format.mp4, 'MP4 (H264)'],
   [Format.av1, 'MP4 (AV1)'],
   [Format.webm, 'WebM'],

--- a/main/utils/fps.ts
+++ b/main/utils/fps.ts
@@ -1,8 +1,5 @@
-import util from 'electron-util';
 import execa from 'execa';
-
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
+import ffmpegPath from './ffmpeg-path';
 
 const getFps = async (filePath: string) => {
   try {

--- a/main/utils/image-preview.ts
+++ b/main/utils/image-preview.ts
@@ -1,16 +1,14 @@
 /* eslint-disable array-element-newline */
 
 import {BrowserWindow, dialog} from 'electron';
-import util from 'electron-util';
 import execa from 'execa';
 import tempy from 'tempy';
 import {promisify} from 'util';
 import type {Video} from '../video';
 import {generateTimestampedName} from './timestamped-name';
+import ffmpegPath from './ffmpeg-path';
 
 const base64Img = require('base64-img');
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-const ffmpegPath = util.fixPathForAsarUnpack(ffmpeg.path);
 
 const getBase64 = promisify(base64Img.base64);
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "electron-util": "^0.14.2",
     "ensure-error": "^3.0.1",
     "execa": "5.0.0",
-    "ffmpeg-static": "^4.3.0",
+    "ffmpeg-static": "^4.4.0",
     "file-icon": "^3.0.0",
     "gifsicle": "^5.2.0",
     "got": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "name": "Kap"
   },
   "dependencies": {
-    "@ffmpeg-installer/ffmpeg": "^1.0.20",
     "@sentry/browser": "^6.2.2",
     "@sentry/electron": "^2.4.0",
     "@sindresorhus/to-milliseconds": "^1.2.0",
@@ -53,6 +52,7 @@
     "electron-util": "^0.14.2",
     "ensure-error": "^3.0.1",
     "execa": "5.0.0",
+    "ffmpeg-static": "^4.3.0",
     "file-icon": "^3.0.0",
     "gifsicle": "^5.2.0",
     "got": "^9.6.0",
@@ -96,6 +96,7 @@
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
     "@sindresorhus/tsconfig": "^0.7.0",
+    "@types/ffmpeg-static": "^3.0.0",
     "@types/got": "9.6.11",
     "@types/insight": "^0.8.0",
     "@types/lodash": "^4.14.168",

--- a/renderer/hooks/editor/use-editor-options.tsx
+++ b/renderer/hooks/editor/use-editor-options.tsx
@@ -9,7 +9,8 @@ const useEditorOptions = createRemoteStateHook<EditorOptionsRemoteState>('editor
     mp4: 60,
     av1: 60,
     webm: 60,
-    apng: 60
+    apng: 60,
+    hevc: 60
   }
 });
 

--- a/test/convert.ts
+++ b/test/convert.ts
@@ -406,3 +406,59 @@ test('av1: non-retina', async t => {
 
   t.false(meta.hasAudio);
 });
+
+// HEVC
+
+test('HEVC: retina', async t => {
+  const onProgress = sinon.fake();
+
+  t.context.outputPath = await convert(Format.hevc, {
+    shouldMute: true,
+    inputPath: retinaInput,
+    fps: 15,
+    width: 469,
+    height: 839,
+    startTime: 30,
+    endTime: 43.5,
+    shouldCrop: true,
+    onProgress
+  });
+
+  const meta = await getVideoMetadata(t.context.outputPath);
+
+  // Makes dimensions even
+  t.is(meta.size.width, 470);
+  t.is(meta.size.height, 840);
+
+  t.is(meta.fps, 15);
+  t.is(meta.encoding, 'hevc');
+
+  t.false(meta.hasAudio);
+
+  t.true(onProgress.calledWithMatch(sinon.match.string, sinon.match.number));
+  t.true(onProgress.calledWithMatch(sinon.match.string, sinon.match.number, sinon.match.string));
+});
+
+test('HEVC: non-retina', async t => {
+  t.context.outputPath = await convert(Format.hevc, {
+    shouldMute: true,
+    inputPath: input,
+    fps: 15,
+    width: 255,
+    height: 143,
+    startTime: 11.5,
+    endTime: 27,
+    shouldCrop: true
+  });
+
+  const meta = await getVideoMetadata(t.context.outputPath);
+
+  // Makes dimensions even
+  t.is(meta.size.width, 256);
+  t.is(meta.size.height, 144);
+
+  t.is(meta.fps, 15);
+  t.is(meta.encoding, 'hevc');
+
+  t.false(meta.hasAudio);
+});

--- a/test/helpers/video-utils.ts
+++ b/test/helpers/video-utils.ts
@@ -1,9 +1,7 @@
 import moment from 'moment';
 import execa from 'execa';
 
-const ffmpeg = require('@ffmpeg-installer/ffmpeg');
-
-const ffmpegPath = ffmpeg.path;
+const ffmpegPath = require('ffmpeg-static');
 
 const getDuration = (text: string): number => {
   const durationString = /Duration: ([\d:.]*)/.exec(text)?.[1];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,10 +4129,10 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-ffmpeg-static@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ffmpeg-static/-/ffmpeg-static-4.3.0.tgz#fa5f689eacb0b3f7ed3eaa52760d132d9db818ec"
-  integrity sha512-w/tXYGlOSeAkPHjypjzylaChLrG5wRzHFyB47KFRDsGyBxUJJWiq9I/39/e6r9Y4aY1gzpejTLg5Aa0aqb0XXA==
+ffmpeg-static@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ffmpeg-static/-/ffmpeg-static-4.4.0.tgz#56f1fbff5dbfd33e368ce309333c8c12ffdafb77"
+  integrity sha512-NIJHVPXlSsIK9pYvsTPh4ZlppauorpPLLeOaIG7VOXWQck4Fx4Qi7Ahe+j8mj8KZXhWwCg3Hx46JdWAIOWLcpg==
   dependencies:
     "@derhuerst/http-basic" "^8.2.0"
     env-paths "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,6 +376,16 @@
   dependencies:
     arrify "^1.0.1"
 
+"@derhuerst/http-basic@^8.2.0":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@derhuerst/http-basic/-/http-basic-8.2.1.tgz#11e3964cf1f2fb40806f9a0fff0c451bb7526093"
+  integrity sha512-Rmn7qQQulw2sxJ8qGfZ7OuqMWuhz8V+L5xnYKMF5cXVcYqmgWqlVEAme90pF7Ya8OVhxVxLmhh0rI2k6t7ITWw==
+  dependencies:
+    caseless "^0.12.0"
+    concat-stream "^1.6.2"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"
@@ -425,54 +435,6 @@
     js-yaml "^3.13.1"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
-
-"@ffmpeg-installer/darwin-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz#48e1706c690e628148482bfb64acb67472089aaa"
-  integrity sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==
-
-"@ffmpeg-installer/ffmpeg@^1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.0.20.tgz#d3c9c2bbcd76149468fb0886c2b3fe9e4795490b"
-  integrity sha512-wbgd//6OdwbFXYgV68ZyKrIcozEQpUKlvV66XHaqO2h3sFbX0jYLzx62Q0v8UcFWN21LoxT98NU2P+K0OWsKNA==
-  optionalDependencies:
-    "@ffmpeg-installer/darwin-x64" "4.1.0"
-    "@ffmpeg-installer/linux-arm" "4.1.3"
-    "@ffmpeg-installer/linux-arm64" "4.1.4"
-    "@ffmpeg-installer/linux-ia32" "4.1.0"
-    "@ffmpeg-installer/linux-x64" "4.1.0"
-    "@ffmpeg-installer/win32-ia32" "4.1.0"
-    "@ffmpeg-installer/win32-x64" "4.1.0"
-
-"@ffmpeg-installer/linux-arm64@4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz#7219f3f901bb67f7926cb060b56b6974a6cad29f"
-  integrity sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==
-
-"@ffmpeg-installer/linux-arm@4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz#c554f105ed5f10475ec25d7bec94926ce18db4c1"
-  integrity sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==
-
-"@ffmpeg-installer/linux-ia32@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz#adad70b0d0d9d8d813983d6e683c5a338a75e442"
-  integrity sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==
-
-"@ffmpeg-installer/linux-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz#b4a5d89c4e12e6d9306dbcdc573df716ec1c4323"
-  integrity sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==
-
-"@ffmpeg-installer/win32-ia32@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz#6eac4fb691b64c02e7a116c1e2d167f3e9b40638"
-  integrity sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==
-
-"@ffmpeg-installer/win32-x64@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz#17e8699b5798d4c60e36e2d6326a8ebe5e95a2c5"
-  integrity sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==
 
 "@hapi/accept@5.0.1":
   version "5.0.1"
@@ -825,6 +787,11 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/ffmpeg-static@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ffmpeg-static/-/ffmpeg-static-3.0.0.tgz#723c2349da9e095cfa0ee6e6c1d5d4c87bb76933"
+  integrity sha512-JTwV8fFQYUgp8VLUKLd8zHfhFOoTTszMlofnWINAZYWSd/iR2ZZHJsWanUhBG4+c8QPfWE8P7t3nAjSxTNjevQ==
+
 "@types/fs-extra@^9.0.7":
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.8.tgz#32c3c07ddf8caa5020f84b5f65a48470519f78ba"
@@ -889,6 +856,11 @@
   version "13.9.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.8.tgz#09976420fc80a7a00bf40680c63815ed8c7616f4"
   integrity sha512-1WgO8hsyHynlx7nhP1kr0OFzsgKz5XDQL+Lfc3b1Q3qIln/n8cKD4m09NJ0+P1Rq7Zgnc7N0+SsMnoD1rEb0kA==
+
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/node@^12.0.12":
   version "12.20.5"
@@ -2102,7 +2074,7 @@ caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz#47ad15b977d2f32b3ec2fe2b087e0c50443771db"
   integrity sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==
 
-caseless@~0.12.0:
+caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
@@ -4157,6 +4129,16 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+ffmpeg-static@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ffmpeg-static/-/ffmpeg-static-4.3.0.tgz#fa5f689eacb0b3f7ed3eaa52760d132d9db818ec"
+  integrity sha512-w/tXYGlOSeAkPHjypjzylaChLrG5wRzHFyB47KFRDsGyBxUJJWiq9I/39/e6r9Y4aY1gzpejTLg5Aa0aqb0XXA==
+  dependencies:
+    "@derhuerst/http-basic" "^8.2.0"
+    env-paths "^2.2.0"
+    https-proxy-agent "^5.0.0"
+    progress "^2.0.3"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4904,6 +4886,13 @@ http-errors@1.7.3:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-response-object@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
+  integrity sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==
+  dependencies:
+    "@types/node" "^10.0.3"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -7097,6 +7086,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  integrity sha1-juqz5U+laSD+Fro493+iGqzC104=
 
 parse-json@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Closes https://github.com/wulkano/kap/issues/629.

Changes:
- Adds support for libx265 / HEVC
- Switches out `@ffmpeg-installer/ffmpeg` for `ffmpeg-static`
	- The ffmpeg versions included by the current package are 3 years out of date. There's talk of [merging it with `ffmpeg-static`](https://github.com/kribblo/node-ffmpeg-installer/issues/55), but currently the latter is more up-to-date. It also [supports M1](https://github.com/eugeneware/ffmpeg-static/releases/tag/b4.4), moving us closer to complete [Apple Silicon support](https://github.com/wulkano/Kap/issues/970).