### PR TITLE
Fix build status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://getkap.co/static/favicon/kap.svg" height="64">
   <h3 align="center">Kap</h3>
   <p align="center">An open-source screen recorder built with web technology<p>
-  <p align="center"><a href="https://circleci.com/gh/wulkano/kap"><img src="https://circleci.com/gh/wulkano/kap.svg?style=shield" alt="Build Status"></a> <a href="https://github.com/sindresorhus/xo"><img src="https://img.shields.io/badge/code_style-XO-5ed9c7.svg" alt="XO code style"></a></p>
+  <p align="center"><a href="https://circleci.com/gh/wulkano/kap"><img src="https://circleci.com/gh/wulkano/Kap.svg?style=shield" alt="Build Status"></a> <a href="https://github.com/sindresorhus/xo"><img src="https://img.shields.io/badge/code_style-XO-5ed9c7.svg" alt="XO code style"></a></p>
 </p>
 
 ## Get Kap


### PR DESCRIPTION
It seems the link is case-sensitive:

![image](https://user-images.githubusercontent.com/44045911/129447470-1dc7d6fa-83e8-4ad2-aab3-f3f42a3777bf.png)
