### PR TITLE
Adjust CI logic for two artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn run dist
-      # - run: mv dist/*.dmg dist/Kap.dmg
+      - run: mv dist/*-x64.dmg dist/Kap-x64.dmg
+      - run: mv dist/*-arm64.dmg dist/Kap-arm64.dmg
       - store_artifacts:
           path: dist/Kap-x64.dmg
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,11 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn run dist
-      - run: mv dist/*.dmg dist/Kap.dmg
+      # - run: mv dist/*.dmg dist/Kap.dmg
       - store_artifacts:
-          path: dist/Kap.dmg
+          path: dist/Kap-x64.dmg
+      - store_artifacts:
+          path: dist/Kap-arm64.dmg
   sentry-release:
     docker:
       - image: cimg/node:lts

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
       }
     },
     "dmg": {
-      "artifactName": "${productName}-${arch}.${ext}",
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "iconSize": 160,
       "contents": [
         {

--- a/package.json
+++ b/package.json
@@ -280,10 +280,14 @@
       },
       "target": {
         "target": "default",
-        "arch": ["x64", "arm64"]
+        "arch": [
+          "x64",
+          "arm64"
+        ]
       }
     },
     "dmg": {
+      "artifactName": "${productName}-${arch}.${ext}",
       "iconSize": 160,
       "contents": [
         {


### PR DESCRIPTION
We had: 
```
mv dist/*.dmg dist/Kap.dmg
```

but with 2 .dmg files generated for Intel/M1 this was failing in CI
Adjusted the logic to upload both artifacts. Also updating the logic for the release endpoint and webhook 