### PR TITLE
Update/replace remote

### DIFF
--- a/main/common/analytics.ts
+++ b/main/common/analytics.ts
@@ -1,8 +1,8 @@
 'use strict';
 
-import util from 'electron-util';
 import {parse} from 'semver';
 import {settings} from './settings';
+import {isFirstAppLaunch} from '../utils/launch';
 
 const Insight = require('insight');
 const pkg = require('../../package');
@@ -21,7 +21,7 @@ export const track = (...paths: string[]) => {
 };
 
 export const initializeAnalytics = () => {
-  if (util.isFirstAppLaunch()) {
+  if (isFirstAppLaunch()) {
     insight.track('install');
   }
 

--- a/main/index.ts
+++ b/main/index.ts
@@ -1,5 +1,5 @@
 import {app} from 'electron';
-import {is, enforceMacOSAppLocation} from 'electron-util';
+import {enforceMacOSAppLocation} from 'electron-util';
 import log from 'electron-log';
 import {autoUpdater} from 'electron-updater';
 import toMilliseconds from '@sindresorhus/to-milliseconds';
@@ -26,6 +26,7 @@ import {setupRemoteStates} from './remote-states';
 import {setUpExportsListeners} from './export';
 import {windowManager} from './windows/manager';
 import {setupProtocol} from './utils/protocol';
+import {isDevelopment} from './utils/environment';
 
 const prepareNext = require('electron-next');
 
@@ -45,7 +46,7 @@ app.on('open-file', (event, path) => {
 });
 
 const initializePlugins = async () => {
-  if (!is.development) {
+  if (!isDevelopment()) {
     try {
       await plugins.upgrade();
     } catch (error) {
@@ -55,7 +56,7 @@ const initializePlugins = async () => {
 };
 
 const checkForUpdates = () => {
-  if (is.development) {
+  if (isDevelopment()) {
     return false;
   }
 

--- a/main/utils/environment.ts
+++ b/main/utils/environment.ts
@@ -1,0 +1,13 @@
+import electron from 'electron';
+
+export const isDevelopment = () => {
+  if (typeof electron === 'string') {
+    throw new TypeError('Not running in an Electron environment!');
+  }
+
+  const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
+  const getFromEnv =
+    Number.parseInt(process.env.ELECTRON_IS_DEV!, 10) === 1;
+
+  return isEnvSet ? getFromEnv : !electron.app.isPackaged;
+};

--- a/main/utils/launch.ts
+++ b/main/utils/launch.ts
@@ -1,0 +1,25 @@
+import Electron from 'electron';
+import fs from 'fs';
+import path from 'path';
+
+export const isFirstAppLaunch = (): boolean => {
+  const checkFile = path.join(
+    Electron.app.getPath('userData'),
+    '.app-launched'
+  );
+
+  if (fs.existsSync(checkFile)) {
+    return false;
+  }
+
+  try {
+    fs.writeFileSync(checkFile, '');
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      fs.mkdirSync(Electron.app.getPath('userData'));
+      return isFirstAppLaunch();
+    }
+  }
+
+  return true;
+};

--- a/main/utils/routes.ts
+++ b/main/utils/routes.ts
@@ -1,8 +1,9 @@
 import {app, BrowserWindow} from 'electron';
-import {is} from 'electron-util';
+
+import {isDevelopment} from './environment';
 
 export const loadRoute = (window: BrowserWindow, routeName: string, {openDevTools}: {openDevTools?: boolean} = {}) => {
-  if (is.development) {
+  if (isDevelopment()) {
     window.loadURL(`http://localhost:8000/${routeName}`);
     window.webContents.openDevTools({mode: 'detach'});
   } else {

--- a/main/utils/sentry.ts
+++ b/main/utils/sentry.ts
@@ -1,13 +1,14 @@
 'use strict';
 
 import {app} from 'electron';
-import {is} from 'electron-util';
 import * as Sentry from '@sentry/electron';
+
 import {settings} from '../common/settings';
+import {isDevelopment} from './environment';
 
 const SENTRY_PUBLIC_DSN = 'https://2dffdbd619f34418817f4db3309299ce@sentry.io/255536';
 
-export const isSentryEnabled = !is.development && settings.get('allowAnalytics');
+export const isSentryEnabled = !isDevelopment() && settings.get('allowAnalytics');
 
 if (isSentryEnabled) {
   const release = `${app.name}@${app.getVersion()}`.toLowerCase();

--- a/main/windows/editor.ts
+++ b/main/windows/editor.ts
@@ -3,10 +3,10 @@ import type {Video} from '../video';
 import KapWindow from './kap-window';
 import {MenuItemId} from '../menus/utils';
 import {BrowserWindow, dialog} from 'electron';
-import {is} from 'electron-util';
 import fs from 'fs';
 import {saveSnapshot} from '../utils/image-preview';
 import {windowManager} from './manager';
+import {isDevelopment} from '../utils/environment';
 
 const pify = require('pify');
 
@@ -40,7 +40,7 @@ const open = async (video: Video) => {
     height: MIN_WINDOW_HEIGHT,
     backgroundColor: '#222222',
     webPreferences: {
-      webSecurity: !is.development // Disable webSecurity in dev to load video over file:// protocol while serving over insecure http, this is not needed in production where we use file:// protocol for html serving.
+      webSecurity: !isDevelopment() // Disable webSecurity in dev to load video over file:// protocol while serving over insecure http, this is not needed in production where we use file:// protocol for html serving.
     },
     frame: false,
     transparent: true,

--- a/renderer/utils/environment.ts
+++ b/renderer/utils/environment.ts
@@ -1,0 +1,13 @@
+import electron from 'electron';
+
+export const isDevelopment = () => {
+  if (typeof electron === 'string') {
+    throw new TypeError('Not running in an Electron environment!');
+  }
+
+  const isEnvSet = 'ELECTRON_IS_DEV' in process.env;
+  const getFromEnv =
+    Number.parseInt(process.env.ELECTRON_IS_DEV, 10) === 1;
+
+  return isEnvSet ? getFromEnv : !electron.app.isPackaged;
+};

--- a/renderer/utils/launch.ts
+++ b/renderer/utils/launch.ts
@@ -1,0 +1,25 @@
+import Electron from 'electron';
+import fs from 'fs';
+import path from 'path';
+
+export const isFirstAppLaunch = (): boolean => {
+  const checkFile = path.join(
+    Electron.app.getPath('userData'),
+    '.app-launched'
+  );
+
+  if (fs.existsSync(checkFile)) {
+    return false;
+  }
+
+  try {
+    fs.writeFileSync(checkFile, '');
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      fs.mkdirSync(Electron.app.getPath('userData'));
+      return isFirstAppLaunch();
+    }
+  }
+
+  return true;
+};

--- a/renderer/utils/sentry-error-boundary.tsx
+++ b/renderer/utils/sentry-error-boundary.tsx
@@ -3,6 +3,8 @@ import * as Sentry from '@sentry/browser';
 import electron from 'electron';
 import type {api as Api, is as Is} from 'electron-util';
 
+import {isDevelopment} from './environment';
+
 const SENTRY_PUBLIC_DSN = 'https://2dffdbd619f34418817f4db3309299ce@sentry.io/255536';
 
 class SentryErrorBoundary extends React.Component<{children: React.ReactNode}> {
@@ -10,12 +12,12 @@ class SentryErrorBoundary extends React.Component<{children: React.ReactNode}> {
     super(props);
     const {settings} = require('@electron/remote').require('./common/settings');
     // Done in-line because this is used in _app
-    const {is, api} = require('electron-util') as {
+    const {api} = require('electron-util') as {
       api: typeof Api;
       is: typeof Is;
     };
 
-    if (!is.development && settings.get('allowAnalytics')) {
+    if (!isDevelopment() && settings.get('allowAnalytics')) {
       const release = `${api.app.name}@${api.app.getVersion()}`.toLowerCase();
       Sentry.init({dsn: SENTRY_PUBLIC_DSN, release});
     }


### PR DESCRIPTION
Before I move any further on this, thought I'd open this up for a review. This PR only removes `is` & `isFirstAppLaunch` so far from `electron-util`,  tests showing no regression.

One thing that stands out to me at first glance in the codebase is utils/ needing to be shared between main/ & renderer/