### PR TITLE
Set conversion video preview max height

### DIFF
--- a/renderer/components/editor/conversion/video-preview.tsx
+++ b/renderer/components/editor/conversion/video-preview.tsx
@@ -99,6 +99,7 @@ const VideoPreview = ({conversion, cancel, showInFolder}: {conversion: UseConver
           flex: 1;
           height: 0;
           -webkit-app-region: no-drag;
+          max-height: 200px;
         }
 
         video, img {


### PR DESCRIPTION
Fixes #1099. The preview height is calculated automatically, so with weird aspect ratios (eg. vertical video) it could grow out of the window.