### PR TITLE
Use icons from Simple Icons CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Download [`main`](https://kap-artifacts.now.sh/main) or builds for any other bra
 
 ## Thanks
 
-- [▲ Vercel](https://vercel.com/) for fast deployments served from the edge, hosting our website, downloads, and updates.
-- [● CircleCI](https://circleci.com/) for supporting the open source community and making our builds fast and reliable.
-- [△ Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
+- [<img height="14" src="https://si-cdn.vercel.app/vercel"/> Vercel](https://vercel.com/) for fast deployments served from the edge, hosting our website, downloads, and updates.
+- [<img height="14" src="https://si-cdn.vercel.app/circleci"/> CircleCI](https://circleci.com/) for supporting the open source community and making our builds fast and reliable.
+- [<img height="14" src="https://si-cdn.vercel.app/sentry"/> Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
 - Our [contributors](https://github.com/wulkano/kap/contributors) who help maintain Kap and make screen recording and sharing easy.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Download [`main`](https://kap-artifacts.now.sh/main) or builds for any other bra
 
 ## Thanks
 
-- [<img height="14" src="https://si-cdn.vercel.app/vercel"/> Vercel](https://vercel.com/) for fast deployments served from the edge, hosting our website, downloads, and updates.
-- [<img height="14" src="https://si-cdn.vercel.app/circleci"/> CircleCI](https://circleci.com/) for supporting the open source community and making our builds fast and reliable.
-- [<img height="14" src="https://si-cdn.vercel.app/sentry"/> Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
+- [<picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/vercel/white"><source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/vercel"><img alt="Vercel" height="14" src="https://cdn.simpleicons.org/vercel"></picture> Vercel](https://vercel.com/) for fast deployments served from the edge, hosting our website, downloads, and updates.
+- [<picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/circleci/white"><source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/circleci"><img alt="CircleCI" height="14" src="https://cdn.simpleicons.org/circleci"></picture> CircleCI](https://circleci.com/) for supporting the open source community and making our builds fast and reliable.
+- [<picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/sentry/white"><source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/sentry"><img alt="CircleCI" height="14" src="https://cdn.simpleicons.org/sentry"></picture> Sentry](https://sentry.io/) for letting us know when Kap isn't behaving and helping us eradicate said behaviour.
 - Our [contributors](https://github.com/wulkano/kap/contributors) who help maintain Kap and make screen recording and sharing easy.


### PR DESCRIPTION
### Simple Icons CDN usage

```
GET https://cdn.simpleicons.org/:icon_slug/:color?
```

All icon slugs can be found at [slugs.md](https://github.com/simple-icons/simple-icons/blob/develop/slugs.md).

- <img height="14" src="https://cdn.simpleicons.org/xo"/> - https://cdn.simpleicons.org/xo
- <img height="14" src="https://cdn.simpleicons.org/vercel"/> - https://cdn.simpleicons.org/vercel
- <img height="14" src="https://cdn.simpleicons.org/vercel/blue"/> - https://cdn.simpleicons.org/vercel/blue
- <img height="14" src="https://cdn.simpleicons.org/vercel/hotpink"/> - https://cdn.simpleicons.org/vercel/hotpink
- <img height="14" src="https://cdn.simpleicons.org/vercel/00ccff"/> - https://cdn.simpleicons.org/vercel/00ccff
- <img height="14" src="https://cdn.simpleicons.org/vercel/f9c"/> - https://cdn.simpleicons.org/vercel/f9c

### References

- Simple Icons - https://github.com/simple-icons/simple-icons
- Simple Icons CDN - https://github.com/LitoMore/simple-icons-cdn