### PR TITLE
add discard warning setting

### DIFF
--- a/main/common/settings.ts
+++ b/main/common/settings.ts
@@ -38,6 +38,7 @@ interface Settings {
     [key in keyof typeof shortcuts]: string
   };
   version: string;
+  showDiscardWarning: boolean;
 }
 
 export const settings = new Store<Settings>({
@@ -123,6 +124,10 @@ export const settings = new Store<Settings>({
     version: {
       type: 'string',
       default: ''
+    },
+    showDiscardWarning: {
+      type: 'boolean',
+      default: true
     }
   }
 });

--- a/main/windows/editor.ts
+++ b/main/windows/editor.ts
@@ -7,6 +7,7 @@ import {is} from 'electron-util';
 import fs from 'fs';
 import {saveSnapshot} from '../utils/image-preview';
 import {windowManager} from './manager';
+import {settings} from '../common/settings';
 
 const pify = require('pify');
 
@@ -86,20 +87,24 @@ const open = async (video: Video) => {
     editorWindow.setDocumentEdited(true);
     editorWindow.on('close', (event: any) => {
       editorsWithNotSavedDialogs.set(video.filePath, true);
-      const buttonIndex = dialog.showMessageBoxSync(editorWindow, {
-        type: 'question',
-        buttons: [
-          'Discard',
-          'Cancel'
-        ],
-        defaultId: 0,
-        cancelId: 1,
-        message: 'Are you sure that you want to discard this recording?',
-        detail: 'You will no longer be able to edit and export the original recording.'
-      });
 
-      if (buttonIndex === 1) {
-        event.preventDefault();
+      const showDiscardWarning = settings.get('showDiscardWarning');
+      if (showDiscardWarning) {
+        const buttonIndex = dialog.showMessageBoxSync(editorWindow, {
+          type: 'question',
+          buttons: [
+            'Discard',
+            'Cancel'
+          ],
+          defaultId: 0,
+          cancelId: 1,
+          message: 'Are you sure that you want to discard this recording?',
+          detail: 'You will no longer be able to edit and export the original recording. You can set Kap to not show this warning in the preferences.'
+        });
+
+        if (buttonIndex === 1) {
+          event.preventDefault();
+        }
       }
 
       editorsWithNotSavedDialogs.delete(video.filePath);

--- a/renderer/components/preferences/categories/general.js
+++ b/renderer/components/preferences/categories/general.js
@@ -54,6 +54,7 @@ class General extends React.Component {
       toggleShortcuts,
       category,
       lossyCompression,
+      showDiscardWarning,
       shortcuts,
       shortcutMap
     } = this.props;
@@ -200,6 +201,18 @@ class General extends React.Component {
             onClick={() => toggleSetting('lossyCompression')}
           />
         </Item>
+        <Item
+          key="showDiscardWarning"
+          parentItem
+          title="Show discard warning"
+          subtitle="Show a warning when discarding a recording."
+        >
+          <Switch
+            tabIndex={tabIndex}
+            checked={showDiscardWarning}
+            onClick={() => toggleSetting('showDiscardWarning')}
+          />
+        </Item>
       </Category>
     );
   }
@@ -227,7 +240,8 @@ General.propTypes = {
   category: PropTypes.string,
   shortcutMap: PropTypes.object,
   shortcuts: PropTypes.object,
-  lossyCompression: PropTypes.bool
+  lossyCompression: PropTypes.bool,
+  showDiscardWarning: PropTypes.bool
 };
 
 export default connect(
@@ -246,6 +260,7 @@ export default connect(
     loopExports,
     category,
     lossyCompression,
+    showDiscardWarning,
     shortcuts,
     shortcutMap
   }) => ({
@@ -262,6 +277,7 @@ export default connect(
     loopExports,
     category,
     lossyCompression,
+    showDiscardWarning,
     shortcuts,
     shortcutMap
   }),


### PR DESCRIPTION
Add a new setting item `showDiscardWarning` to control the message box when try to close editor window. 
related issue https://github.com/wulkano/Kap/issues/1143