### PR TITLE
Disable SSR for the renderer app shell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,19 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: '13.4.1'
+      xcode: '14.3.1'
+    resource_class: m4pro.medium
     steps:
       - checkout
+      - run:
+          name: Use Node 16
+          command: |
+            nvm install 16.20.2
+            nvm alias default 16.20.2
+            echo 'export PATH="$HOME/.nvm/versions/node/v16.20.2/bin:$PATH"' >> "$BASH_ENV"
+      - run:
+          name: Install native build tools
+          command: brew install automake
       - run: yarn
       - run: mkdir -p ~/reports
       - run: yarn lint

--- a/renderer/components/kap-app.tsx
+++ b/renderer/components/kap-app.tsx
@@ -1,0 +1,25 @@
+import {AppProps} from 'next/app';
+import classNames from 'classnames';
+
+import useDarkMode from '../hooks/dark-mode';
+import GlobalStyles from '../utils/global-styles';
+import SentryErrorBoundary from '../utils/sentry-error-boundary';
+import {WindowStateProvider} from '../hooks/window-state';
+
+const KapApp = ({Component, pageProps}: AppProps) => {
+  const isDarkMode = useDarkMode();
+  const className = classNames('cover-window', {dark: isDarkMode});
+
+  return (
+    <div className={className}>
+      <SentryErrorBoundary>
+        <WindowStateProvider>
+          <Component {...pageProps}/>
+          <GlobalStyles/>
+        </WindowStateProvider>
+      </SentryErrorBoundary>
+    </div>
+  );
+};
+
+export default KapApp;

--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -12,7 +12,9 @@ module.exports = (nextConfig) => {
         ]
       });
 
-      config.target = 'electron-renderer';
+      if (!options.isServer) {
+        config.target = 'electron-renderer';
+      }
       config.devtool = 'cheap-module-source-map';
 
       if (typeof nextConfig.webpack === 'function') {

--- a/renderer/pages/_app.tsx
+++ b/renderer/pages/_app.tsx
@@ -1,39 +1,8 @@
 import {AppProps} from 'next/app';
-import {useState, useEffect} from 'react';
-import useDarkMode from '../hooks/dark-mode';
-import GlobalStyles from '../utils/global-styles';
-import SentryErrorBoundary from '../utils/sentry-error-boundary';
-import {WindowStateProvider} from '../hooks/window-state';
-import classNames from 'classnames';
+import dynamic from 'next/dynamic';
 
-const Kap = (props: AppProps) => {
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  if (!isMounted) {
-    return null;
-  }
-
-  return <MainApp {...props}/>;
-};
-
-const MainApp = ({Component, pageProps}: AppProps) => {
-  const isDarkMode = useDarkMode();
-  const className = classNames('cover-window', {dark: isDarkMode});
-
-  return (
-    <div className={className}>
-      <SentryErrorBoundary>
-        <WindowStateProvider>
-          <Component {...pageProps}/>
-          <GlobalStyles/>
-        </WindowStateProvider>
-      </SentryErrorBoundary>
-    </div>
-  );
-};
+const Kap = dynamic<AppProps>(async () => import('../components/kap-app'), {
+  ssr: false
+});
 
 export default Kap;


### PR DESCRIPTION
Fixes #515

## Summary
- Move the Electron-dependent app wrapper out of `_app` into a client-only app shell loaded with `next/dynamic({ssr: false})`.
- Remove the mounted-state workaround from `_app`, so Next handles skipping server rendering directly.
- Scope the custom `electron-renderer` webpack target to the client build only; the server/export build keeps the normal Node target and can evaluate dynamic imports without requiring `window`.
- Update CircleCI to a currently supported macOS image while keeping Kap on Node 16 for the existing dependency graph.

## Verification
- `npx -p node@16 -c 'node ./node_modules/.bin/xo'` passed with existing warnings only.
- `npx -p node@16 -c 'node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.json'`
- `npx tsc --noEmit -p renderer/tsconfig.json`
- `npx -p node@16 -c 'node ./node_modules/next/dist/bin/next build renderer && node ./node_modules/next/dist/bin/next export renderer'`
- Checked exported renderer HTML, e.g. `renderer/out/editor.html`, renders an empty `#__next` shell rather than server-rendering the Electron UI.
- CircleCI `build` passed on this PR after the CI image update.

Note: I installed dependencies locally with `yarn install --frozen-lockfile --ignore-scripts --ignore-engines` because this older lockfile rejects modern Node during the engine check, then ran `node node_modules/electron/install.js` so the renderer build could import Electron during page-data collection.